### PR TITLE
Update fetch functions and guzzle client instanceissue

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Check & fix styling](https://github.com/Thavarshan/fetch-php/actions/workflows/php-cs-fixer.yml/badge.svg?label=code%20style&branch=main)](https://github.com/Thavarshan/fetch-php/actions/workflows/php-cs-fixer.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/jerome/fetch-php.svg)](https://packagist.org/packages/jerome/fetch-php)
 
-FetchPHP is a PHP library that mimics the behavior of JavaScript’s `fetch` API using the powerful Guzzle HTTP client. FetchPHP supports both synchronous and asynchronous requests, and provides an easy-to-use, flexible API for making HTTP requests in PHP.
+FetchPHP is a PHP library that mimics the behavior of JavaScript’s `fetch` API using the powerful Guzzle HTTP client. FetchPHP supports both synchronous and asynchronous requests and provides an easy-to-use, flexible API for making HTTP requests in PHP.
 
 ## **Installation**
 
@@ -24,27 +24,69 @@ composer require jerome/fetch-php
 FetchPHP provides two main functions:
 
 1. **`fetch`** – Performs a **synchronous** HTTP request.
-2. **`fetchAsync`** – Performs an **asynchronous** HTTP request and returns a Guzzle `PromiseInterface`.
+2. **`fetch_async`** – Performs an **asynchronous** HTTP request and returns a Guzzle `PromiseInterface`.
+
+> **Deprecation Warning:** The function `fetchAsync` has been deprecated in version `1.1.0`. Please use `fetch_async` instead. If you continue using `fetchAsync`, you will see a deprecation warning in your code.
 
 ---
 
-### **Important Consideration: Guzzle Client Instantiation**
+### **Guzzle Client Instantiation and Static Variables**
 
-By default, the Guzzle HTTP client is instantiated every time the `fetch` or `fetchAsync` function is called. While this is fine for most cases, it can introduce some inefficiency if you're making frequent HTTP requests in your application.
+By default, FetchPHP uses a **singleton** pattern to create and reuse the Guzzle HTTP client across multiple `fetch` or `fetch_async` function calls. This ensures that a new client is not created for every request, reducing overhead. If you do not pass a custom client, the first time you call `fetch`, a new Guzzle client will be created and stored as a **static variable**. All subsequent requests will reuse this client.
 
-#### **Mitigating Guzzle Client Reinstantiation**
+#### **Static Variables and Potential Risks**
 
-You can mitigate the overhead of creating a new Guzzle client each time by passing a custom Guzzle client through the `options` parameter. This allows you to use a **singleton instance** of the client across multiple `fetch` requests.
+While using a static variable for the Guzzle client improves performance by avoiding repeated client instantiation, it introduces some potential issues that you should be aware of:
 
-### **How to Provide a Custom Guzzle Client**
+1. **Shared State and Configuration**:
+    - Any changes to the static client configuration (e.g., headers, base URI, timeouts) will persist across all subsequent requests. This could lead to unexpected behavior if different configurations are required for different requests.
+    - **Mitigation**: Always pass explicit configurations (like `headers`, `auth`, or `timeout`) in the options parameter for every request. This ensures that each request uses the intended configuration.
+
+    Example:
+
+    ```php
+    $response1 = fetch('/endpoint1', ['headers' => ['Authorization' => 'Bearer token1']]);
+    $response2 = fetch('/endpoint2', ['headers' => ['Authorization' => 'Bearer token2']]);  // Independent headers
+    ```
+
+2. **Memory Leaks in Long-Running Processes**:
+    - If the application is a long-running process (e.g., a worker or daemon), the static Guzzle client will remain in memory. Over time, it could accumulate state (such as cookies or connection pools) and potentially cause memory issues.
+    - **Mitigation**: If your application is long-running, consider resetting or replacing the static Guzzle client at regular intervals, especially if there is a risk of accumulated state affecting performance.
+
+3. **Concurrency and Thread Safety**:
+    - In environments where concurrent requests are made (e.g., using Swoole or ReactPHP), the static client could introduce thread-safety issues. Since PHP is not inherently multi-threaded, this is not a concern for standard PHP web applications. However, in concurrent environments, race conditions could occur.
+    - **Mitigation**: In environments with concurrent requests, avoid using static variables for the Guzzle client. Instead, instantiate separate Guzzle clients or use dependency injection for better control over individual request contexts.
+
+4. **Global Impact**:
+    - Modifying the static Guzzle client affects all subsequent requests globally. If different services or APIs are accessed with different configurations, this could cause unexpected side effects.
+    - **Mitigation**: Always pass client-specific configurations in the options, or use separate Guzzle client instances for different services.
+
+    In applications where more granular control over the client lifecycle is required, or in environments with dependency injection support, consider passing the Guzzle client explicitly via service containers or dependency injection frameworks.
+
+#### **Using a Custom Guzzle Client with Middleware Support**
+
+If you want to provide a custom Guzzle client (with custom configurations or middleware), you can pass it through the `options` parameter. This allows you to add middleware for things like logging, retries, caching, etc.
 
 ```php
 <?php
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
 
-// Create a singleton instance of Guzzle client
+// Create a Guzzle handler stack with custom middleware
+$stack = HandlerStack::create();
+
+// Add custom middleware to the handler stack
+$stack->push(Middleware::mapRequest(function (RequestInterface $request) {
+    // Example middleware to modify the request
+    return $request->withHeader('X-Custom-Header', 'Value');
+}));
+
+// Create a singleton instance of Guzzle client with middleware
 $client = new Client([
+    'handler' => $stack,
     'base_uri' => 'https://jsonplaceholder.typicode.com',
     'timeout' => 10.0,
     // Other default options
@@ -64,12 +106,14 @@ print_r($response->json());
 print_r($response2->json());
 ```
 
-### **Why use a Singleton?**
+### **Why is Singleton Guzzle Client Useful?**
 
 Passing a singleton Guzzle client is useful when:
 
 - You're making many requests and want to avoid the overhead of creating a new client each time.
 - You want to configure specific client-wide options (e.g., base URI, timeouts, headers) and use them across multiple requests.
+- You want to apply custom middleware to every request made by the client (e.g., logging, retries, etc.).
+- If different configurations are needed for different requests, you can pass a new instance of the Guzzle client in the `options` parameter to bypass the singleton behavior.
 
 ---
 
@@ -96,7 +140,7 @@ echo $response->statusText();
 
 #### **Available Response Methods**
 
-- **`json(bool $assoc = true)`**: Decodes the response body as JSON. If `$assoc` is `true`, it returns an associative array. If `false`, it returns an object.
+- **`json(bool $assoc = true)`**: Decodes the response body as JSON. If `$assoc` is `true`, it returns an associative array. If `false`, it returns an object. If the JSON decoding fails, a `RuntimeException` will be thrown. Ensure you handle this exception when working with potentially malformed JSON responses.
 - **`text()`**: Returns the response body as plain text.
 - **`blob()`**: Returns the response body as a PHP stream resource (like a "blob").
 - **`arrayBuffer()`**: Returns the response body as a binary string.
@@ -106,9 +150,9 @@ echo $response->statusText();
 
 ---
 
-### **2. Asynchronous Requests with `fetchAsync`**
+### **2. Asynchronous Requests with `fetch_async`**
 
-The `fetchAsync` function returns a `PromiseInterface` object. You can use the `.then()` and `.wait()` methods to manage the asynchronous flow.
+The `fetch_async` function returns a `PromiseInterface` object. You can use the `.then()` and `.wait()` methods to manage the asynchronous flow.
 
 #### **Basic Asynchronous GET Request Example**
 
@@ -117,15 +161,19 @@ The `fetchAsync` function returns a `PromiseInterface` object. You can use the `
 
 require 'vendor/autoload.php';
 
-$promise = fetchAsync('https://jsonplaceholder.typicode.com/todos/1');
+$data = [];
 
-$promise->then(function ($response) {
+$promise = fetch_async('https://jsonplaceholder.typicode.com/todos/1');
+
+$promise->then(function ($response) use (&$data) {
     $data = $response->json();
     print_r($data);
 });
 
 // Wait for the promise to resolve
 $promise->wait();
+
+echo "Data received: " . $data['title'];
 ```
 
 #### **Error Handling in Asynchronous Requests**
@@ -133,7 +181,7 @@ $promise->wait();
 You can handle errors with the `catch` or `then` method of the promise:
 
 ```php
-$promise = fetchAsync('https://nonexistent-url.com');
+$promise = fetch_async('https://nonexistent-url.com');
 
 $promise->then(function ($response) {
     // handle success
@@ -149,7 +197,7 @@ $promise->wait();
 
 ## **Request Options**
 
-FetchPHP accepts an array of options as the second argument in both `fetch` and `fetchAsync`. These options configure how the request is handled.
+FetchPHP accepts an array of options as the second argument in both `fetch` and `fetch_async`. These options configure how the request is handled.
 
 ### **Available Request Options**
 
@@ -269,9 +317,7 @@ You can control timeouts and whether redirects are followed:
 <?php
 
 $response = fetch('https://example.com/slow-request', [
-
-
- 'timeout' => 5,   // 5-second timeout
+    'timeout' => 5,   // 5-second timeout
     'allow_redirects' => false
 ]);
 
@@ -300,7 +346,7 @@ echo $response->text();  // Outputs error message
 ```php
 <?php
 
-$promise = fetchAsync('https://nonexistent-url.com');
+$promise = fetch_async('https://nonexistent-url.com');
 
 $promise->then(function ($response) {
     echo $response->text();
@@ -351,7 +397,7 @@ The `Response` class provides convenient methods for interacting with the respon
 
 #### **Response Methods Overview**
 
-- **`json()`**: Decodes the response body as JSON.
+- **`json()`**: Decodes the response body as JSON. If the JSON decoding fails, a `RuntimeException` is thrown.
 - **`text()`**: Returns the raw response body as plain text.
 - **`blob()`**: Returns the body as a PHP stream (useful for file handling).
 - **`arrayBuffer()`**: Returns the body as a binary string.

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
             "Fetch\\": "src/"
         },
         "files": [
-            "src/fetch.php",
-            "src/helpers.php"
+            "src/fetch.php"
         ]
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jerome/fetch-php",
     "description": "The fetch API for PHP.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -20,7 +20,8 @@
             "Fetch\\": "src/"
         },
         "files": [
-            "src/fetch.php"
+            "src/fetch.php",
+            "src/helpers.php"
         ]
     },
     "require": {

--- a/src/Response.php
+++ b/src/Response.php
@@ -27,6 +27,7 @@ class Response extends SymfonyResponse
         // Buffer the body contents to allow multiple reads
         $this->bodyContents = (string) $guzzleResponse->getBody();
 
+        // Pass the string body to the Symfony Response
         parent::__construct(
             $this->bodyContents,
             $guzzleResponse->getStatusCode(),
@@ -43,13 +44,20 @@ class Response extends SymfonyResponse
      */
     public function json(bool $assoc = true)
     {
+        // Handle empty body by returning null or an empty array/object
+        if (trim($this->bodyContents) === '') {
+            return $assoc ? [] : null;
+        }
+
         $decoded = json_decode($this->bodyContents, $assoc);
+
         if (json_last_error() !== \JSON_ERROR_NONE) {
             throw new RuntimeException('Failed to decode JSON: ' . json_last_error_msg());
         }
 
         return $decoded;
     }
+
 
     /**
      * Get the body as plain text.
@@ -69,9 +77,11 @@ class Response extends SymfonyResponse
     public function blob()
     {
         $stream = fopen('php://memory', 'r+');
+
         if ($stream === false) {
             return false;
         }
+
         fwrite($stream, $this->bodyContents);
         rewind($stream);
 

--- a/src/fetch.php
+++ b/src/fetch.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 if (! function_exists('fetch')) {
     /**
@@ -20,7 +21,7 @@ if (! function_exists('fetch')) {
      */
     function fetch(string $url, array $options = []): Response
     {
-        return makeRequest($url, $options, false);
+        return make_request($url, $options, false);
     }
 }
 
@@ -32,14 +33,34 @@ if (! function_exists('fetchAsync')) {
      * @param array  $options
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
+     *
+     * @deprecated version 1.1.0 Use fetch_async instead
      */
     function fetchAsync(string $url, array $options = []): PromiseInterface
     {
-        return makeRequest($url, $options, true);
+        // Emit a warning to notify about the deprecation
+        trigger_error('fetchAsync is deprecated. Use fetch_async instead.', \E_USER_DEPRECATED);
+
+        return make_request($url, $options, true);
     }
 }
 
-if (! function_exists('makeRequest')) {
+if (! function_exists('fetch_async')) {
+    /**
+     * Asynchronous version of the fetch function.
+     *
+     * @param string $url
+     * @param array  $options
+     *
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    function fetch_async(string $url, array $options = []): PromiseInterface
+    {
+        return make_request($url, $options, true);
+    }
+}
+
+if (! function_exists('make_request')) {
     /**
      * Helper function to perform HTTP requests using Guzzle.
      *
@@ -49,33 +70,41 @@ if (! function_exists('makeRequest')) {
      *
      * @return \GuzzleHttp\Promise\PromiseInterface|\Fetch\Response
      */
-    function makeRequest(
+    function make_request(
         string $url,
         array $options,
         bool $async
     ): PromiseInterface|Response {
-        $client = $options['client'] ?? new Client([
-            'base_uri' => $options['base_uri'] ?? null,
-            'timeout' => $options['timeout'] ?? 10.0,
-            'allow_redirects' => $options['allow_redirects'] ?? true,
-            'cookies' => isset($options['cookies']) ? new CookieJar() : false,
-            'verify' => $options['verify'] ?? true,
-            'proxy' => $options['proxy'] ?? null,
-        ]);
+        // Store the Guzzle client as a static variable to retain its instance
+        static $defaultClient;
 
-        $method = $options['method'] ?? 'GET';
-        $headers = $options['headers'] ?? [];
-        $body = $options['body'] ?? null;
-        $query = $options['query'] ?? [];
+        // Use provided client or the default one
+        $client = $options['client'] ?? $defaultClient;
 
-        if (isset($options['multipart'])) {
-            $body = new MultipartStream($options['multipart']);
-            $headers['Content-Type'] = 'multipart/form-data';
-        } elseif (isset($options['json'])) {
-            $body = json_encode($options['json']);
-            $headers['Content-Type'] = 'application/json';
+        // Initialize default client if none provided or not already initialized
+        if (! $client) {
+            $defaultClient = new Client([
+                'base_uri' => $options['base_uri'] ?? null,
+                'timeout' => $options['timeout'] ?? 0,
+                'allow_redirects' => $options['allow_redirects'] ?? true,
+                'cookies' => isset($options['cookies']) ? new CookieJar() : false,
+                'verify' => $options['verify'] ?? true,
+                'proxy' => $options['proxy'] ?? null,
+            ]);
+
+            $client = $defaultClient;
         }
 
+        // Prepare request method and options
+        $method = $options['method'] ?? 'GET';
+        $headers = $options['headers'] ?? [];
+
+        // Prepare the request body and update headers if necessary
+        [$body, $headers] = prepare_body($options, $headers);
+
+        $query = $options['query'] ?? [];
+
+        // Build request options array
         $requestOptions = [
             'headers' => $headers,
             'body' => $body,
@@ -83,32 +112,113 @@ if (! function_exists('makeRequest')) {
             'auth' => $options['auth'] ?? null,
         ];
 
+        // Handle async request
         if ($async) {
-            return $client->requestAsync($method, $url, $requestOptions)->then(
-                fn (ResponseInterface $response) => new Response($response),
-                fn (RequestException $e) => $e->hasResponse()
-                    ? new Response($e->getResponse())
-                    : createErrorResponse($e)
-            );
+            return handle_async_request($client, $method, $url, $requestOptions);
         }
 
+        // Handle synchronous request
+        return handle_sync_request($client, $method, $url, $requestOptions);
+    }
+}
+
+if (! function_exists('prepare_body')) {
+    /**
+     * Prepare the request body based on the given options.
+     *
+     * @param array $options
+     * @param array $headers
+     *
+     * @return array Returns the body and updated headers
+     */
+    function prepare_body(array $options, array $headers): array
+    {
+        if (isset($options['multipart'])) {
+            $body = new MultipartStream($options['multipart']);
+            $headers['Content-Type'] = 'multipart/form-data';
+
+            return [$body, $headers];
+        }
+
+        if (isset($options['json'])) {
+            $body = json_encode($options['json']);
+            $headers['Content-Type'] = 'application/json';
+
+            return [$body, $headers];
+        }
+
+        return [$options['body'] ?? null, $headers];
+    }
+}
+
+if (! function_exists('handle_async_request')) {
+    /**
+     * Handle an asynchronous HTTP request.
+     *
+     * @param \GuzzleHttp\Client $client
+     * @param string             $method
+     * @param string             $url
+     * @param array              $requestOptions
+     *
+     * @return \GuzzleHttp\Promise\PromiseInterface
+     */
+    function handle_async_request(
+        Client $client,
+        string $method,
+        string $url,
+        array $requestOptions
+    ): PromiseInterface {
+        return $client->requestAsync($method, $url, $requestOptions)->then(
+            fn (ResponseInterface $response) => new Response($response),
+            fn (RequestException $e) => handle_request_exception($e)
+        );
+    }
+}
+
+if (! function_exists('handle_sync_request')) {
+    /**
+     * Handle a synchronous HTTP request.
+     *
+     * @param \GuzzleHttp\Client $client
+     * @param string             $method
+     * @param string             $url
+     * @param array              $requestOptions
+     *
+     * @return \Fetch\Response
+     */
+    function handle_sync_request(
+        Client $client,
+        string $method,
+        string $url,
+        array $requestOptions
+    ): Response {
         try {
             $response = $client->request($method, $url, $requestOptions);
 
             return new Response($response);
         } catch (RequestException $e) {
-            $response = $e->getResponse();
-
-            if ($response) {
-                return new Response($response);
-            }
-
-            return createErrorResponse($e);
+            return handle_request_exception($e);
         }
     }
 }
 
-if (! function_exists('createErrorResponse')) {
+if (! function_exists('handle_request_exception')) {
+    /**
+     * Handle a request exception and return a mock response.
+     *
+     * @param \GuzzleHttp\Exception\RequestException $e
+     *
+     * @return \Fetch\Response
+     */
+    function handle_request_exception(RequestException $e): Response
+    {
+        $response = $e->getResponse();
+
+        return $response ? new Response($response) : create_error_response($e);
+    }
+}
+
+if (! function_exists('create_error_response')) {
     /**
      * Creates a mock response for error handling.
      *
@@ -116,10 +226,10 @@ if (! function_exists('createErrorResponse')) {
      *
      * @return \Fetch\Response
      */
-    function createErrorResponse(RequestException $e): Response
+    function create_error_response(RequestException $e): Response
     {
         $mockResponse = new GuzzleResponse(
-            500,
+            SymfonyResponse::HTTP_INTERNAL_SERVER_ERROR,
             [],
             $e->getMessage()
         );

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,8 +2,8 @@
 
 use Fetch\Response;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use RuntimeException;
 
-// Test the json() method of the Response class
 test('Response::json() correctly decodes JSON', function () {
     $guzzleResponse = new GuzzleResponse(200, ['Content-Type' => 'application/json'], '{"key":"value"}');
     $response = new Response($guzzleResponse);
@@ -12,7 +12,13 @@ test('Response::json() correctly decodes JSON', function () {
     expect($json)->toMatchArray(['key' => 'value']);
 });
 
-// Test the text() method of the Response class
+test('Response::json() throws exception for invalid JSON', function () {
+    $guzzleResponse = new GuzzleResponse(200, ['Content-Type' => 'application/json'], 'Invalid JSON');
+    $response = new Response($guzzleResponse);
+
+    expect(fn () => $response->json())->toThrow(RuntimeException::class, 'Failed to decode JSON');
+});
+
 test('Response::text() correctly retrieves plain text', function () {
     $guzzleResponse = new GuzzleResponse(200, [], 'Plain text content');
     $response = new Response($guzzleResponse);
@@ -20,16 +26,16 @@ test('Response::text() correctly retrieves plain text', function () {
     expect($response->text())->toBe('Plain text content');
 });
 
-// Test the blob() method of the Response class
 test('Response::blob() correctly retrieves blob (stream)', function () {
     $guzzleResponse = new GuzzleResponse(200, [], 'Binary data');
     $response = new Response($guzzleResponse);
 
     $blob = $response->blob();
     expect(is_resource($blob))->toBeTrue();
+    expect(stream_get_contents($blob))->toBe('Binary data');
+    fclose($blob);
 });
 
-// Test the arrayBuffer() method of the Response class
 test('Response::arrayBuffer() correctly retrieves binary data as string', function () {
     $guzzleResponse = new GuzzleResponse(200, [], 'Binary data');
     $response = new Response($guzzleResponse);
@@ -37,7 +43,6 @@ test('Response::arrayBuffer() correctly retrieves binary data as string', functi
     expect($response->arrayBuffer())->toBe('Binary data');
 });
 
-// Test the statusText() method of the Response class
 test('Response::statusText() correctly retrieves status text', function () {
     $guzzleResponse = new GuzzleResponse(200);
     $response = new Response($guzzleResponse);
@@ -45,7 +50,6 @@ test('Response::statusText() correctly retrieves status text', function () {
     expect($response->statusText())->toBe('OK');
 });
 
-// Test the status helpers
 test('Response status helper methods work correctly', function () {
     $informationalResponse = new Response(new GuzzleResponse(100));
     $successfulResponse = new Response(new GuzzleResponse(200));
@@ -60,7 +64,6 @@ test('Response status helper methods work correctly', function () {
     expect($serverErrorResponse->isServerError())->toBeTrue();
 });
 
-// Test error handling by simulating a failed response
 test('Response handles error gracefully', function () {
     $errorMessage = 'Something went wrong';
     $guzzleResponse = new GuzzleResponse(500, [], $errorMessage);
@@ -68,4 +71,20 @@ test('Response handles error gracefully', function () {
 
     expect($response->getStatusCode())->toBe(500);
     expect($response->text())->toBe($errorMessage);
+});
+
+test('Response handles empty body and returns empty array when $assoc is true', function () {
+    $guzzleResponse = new GuzzleResponse(200, ['Content-Type' => 'application/json'], '');
+    $response = new Response($guzzleResponse);
+
+    expect($response->text())->toBe('');
+    expect($response->json(true))->toBe([]);
+});
+
+test('Response handles empty body and returns null when $assoc is false', function () {
+    $guzzleResponse = new GuzzleResponse(200, ['Content-Type' => 'application/json'], '');
+    $response = new Response($guzzleResponse);
+
+    expect($response->text())->toBe('');
+    expect($response->json(false))->toBeNull();
 });


### PR DESCRIPTION
## **Purpose**

This pull request introduces **v1.1.0** of FetchPHP, addressing key improvements in performance, flexibility, and error handling, while introducing custom middleware support. The most significant change is the deprecation of the `fetchAsync` function in favor of the more consistent `fetch_async`.

**Linked Issues:**
- Improves client efficiency by reusing a singleton Guzzle client.
- Addresses edge cases related to empty or malformed JSON handling.
- Allows developers to add custom middleware for advanced request management (e.g., retries, logging).

---

## **Approach**

### **How does this change address the problem?**

- **Singleton Guzzle Client**: By using a static variable, the Guzzle client is instantiated once and reused for multiple requests, reducing overhead. This improves performance, especially in applications making frequent HTTP requests.
- **Custom Middleware Support**: Developers can pass a custom Guzzle client with middleware via the `options['client']` parameter, adding flexibility for logging, retries, and request manipulation.
- **Deprecation of `fetchAsync`**: To improve consistency, `fetchAsync` has been deprecated, and `fetch_async` is introduced. The new naming scheme aligns with best practices and future-proofs the library.
- **Enhanced JSON and Error Handling**: The `Response::json()` method now handles empty or malformed responses more gracefully, throwing exceptions for decoding errors while returning `null` for empty bodies.

---

#### **Open Questions and Pre-Merge TODOs**

- [ ] **Deprecation Handling**: Have we sufficiently warned users about the deprecation of `fetchAsync` in all documentation?
- [ ] **Documentation Updates**: Is the newly added example for custom middleware comprehensive enough?
- [ ] **Thread Safety Considerations**: Should we provide more guidance for using FetchPHP in multi-threaded environments where the static client might introduce concurrency issues?

---

## **Learning**

During the research for this release, we investigated:

1. **Singleton Design Pattern**: Studied the impact of reusing a single Guzzle client to minimize memory usage and reduce the overhead of repeated instantiation.
2. **Custom Middleware Implementation**: Reviewed Guzzle's middleware stack to ensure that FetchPHP could support logging, caching, and retry mechanisms.
3. **Error Handling Best Practices**: Investigated proper handling of JSON decoding errors, ensuring that developers receive clear feedback for empty or malformed responses.

---

This pull request aims to make FetchPHP more robust and versatile while maintaining a smooth migration path for existing users while also pereparing for release of version `1.1.0`. Let us know if any changes or additional feedback are needed before the merge!