### PR TITLE
Use guzzlehttp/psr7 instead of symfony/http-foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ FetchPHP provides three main functions:
 
 ### **Custom Guzzle Client Usage**
 
-By default, FetchPHP uses a single instance of the Guzzle client shared across all requests. However, you can provide your own Guzzle client through the `options` parameter of both `fetch` and `fetch_async`. This gives you full control over the client configuration, including base URI, headers, timeouts, and more.
+By default, FetchPHP uses a singleton instance of the Guzzle client shared across all requests. However, you can provide your own Guzzle client through the `options` parameter of both `fetch` and `fetch_async`. This gives you full control over the client configuration, including base URI, headers, timeouts, and more.
 
 ### **How to Provide a Custom Guzzle Client**
 
@@ -91,6 +91,8 @@ echo $response->statusText();
 ```
 
 #### **Available Response Methods**
+
+The `Response` class, now based on Guzzle’s `Psr7\Response`, provides various methods to interact with the response data:
 
 - **`json(bool $assoc = true)`**: Decodes the response body as JSON. If `$assoc` is `true`, it returns an associative array. If `false`, it returns an object.
 - **`text()`**: Returns the response body as plain text.
@@ -238,7 +240,9 @@ echo $response->text();  // Outputs error message
 
 $promise = fetch_async('https://nonexistent-url.com');
 
-$promise->then(function ($response) {
+$promise->then(function ($
+
+response) {
     echo $response->text();
 }, function ($exception) {
     echo "Request failed: " . $exception->getMessage();
@@ -281,9 +285,7 @@ echo $response->statusText();
 
 ---
 
-### **Working
-
- with the Response Object**
+### **Working with the Response Object**
 
 The `Response` class provides convenient methods for interacting with the response body, headers, and status codes.
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "jerome/fetch-php",
     "description": "The JavaScript fetch API for PHP.",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.8",
-        "psr/http-message": "^1.0 || ^2.0",
-        "symfony/http-foundation": "^6.0 || ^7.1"
+        "guzzlehttp/psr7": "^2.7",
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64",

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -5,7 +5,13 @@ use GuzzleHttp\Psr7\Response as GuzzleResponse;
 
 test('Response::json() correctly decodes JSON', function () {
     $guzzleResponse = new GuzzleResponse(200, ['Content-Type' => 'application/json'], '{"key":"value"}');
-    $response = new Response($guzzleResponse);
+    $response = new Response(
+        $guzzleResponse->getStatusCode(),
+        $guzzleResponse->getHeaders(),
+        (string) $guzzleResponse->getBody(),
+        $guzzleResponse->getProtocolVersion(),
+        $guzzleResponse->getReasonPhrase()
+    );
 
     $json = $response->json();
     expect($json)->toMatchArray(['key' => 'value']);
@@ -13,14 +19,26 @@ test('Response::json() correctly decodes JSON', function () {
 
 test('Response::text() correctly retrieves plain text', function () {
     $guzzleResponse = new GuzzleResponse(200, [], 'Plain text content');
-    $response = new Response($guzzleResponse);
+    $response = new Response(
+        $guzzleResponse->getStatusCode(),
+        $guzzleResponse->getHeaders(),
+        (string) $guzzleResponse->getBody(),
+        $guzzleResponse->getProtocolVersion(),
+        $guzzleResponse->getReasonPhrase()
+    );
 
     expect($response->text())->toBe('Plain text content');
 });
 
 test('Response::blob() correctly retrieves blob (stream)', function () {
     $guzzleResponse = new GuzzleResponse(200, [], 'Binary data');
-    $response = new Response($guzzleResponse);
+    $response = new Response(
+        $guzzleResponse->getStatusCode(),
+        $guzzleResponse->getHeaders(),
+        (string) $guzzleResponse->getBody(),
+        $guzzleResponse->getProtocolVersion(),
+        $guzzleResponse->getReasonPhrase()
+    );
 
     $blob = $response->blob();
     expect(is_resource($blob))->toBeTrue();
@@ -28,24 +46,36 @@ test('Response::blob() correctly retrieves blob (stream)', function () {
 
 test('Response::arrayBuffer() correctly retrieves binary data as string', function () {
     $guzzleResponse = new GuzzleResponse(200, [], 'Binary data');
-    $response = new Response($guzzleResponse);
+    $response = new Response(
+        $guzzleResponse->getStatusCode(),
+        $guzzleResponse->getHeaders(),
+        (string) $guzzleResponse->getBody(),
+        $guzzleResponse->getProtocolVersion(),
+        $guzzleResponse->getReasonPhrase()
+    );
 
     expect($response->arrayBuffer())->toBe('Binary data');
 });
 
 test('Response::statusText() correctly retrieves status text', function () {
     $guzzleResponse = new GuzzleResponse(200);
-    $response = new Response($guzzleResponse);
+    $response = new Response(
+        $guzzleResponse->getStatusCode(),
+        $guzzleResponse->getHeaders(),
+        (string) $guzzleResponse->getBody(),
+        $guzzleResponse->getProtocolVersion(),
+        $guzzleResponse->getReasonPhrase()
+    );
 
     expect($response->statusText())->toBe('OK');
 });
 
 test('Response status helper methods work correctly', function () {
-    $informationalResponse = new Response(new GuzzleResponse(100));
-    $successfulResponse = new Response(new GuzzleResponse(200));
-    $redirectionResponse = new Response(new GuzzleResponse(301));
-    $clientErrorResponse = new Response(new GuzzleResponse(404));
-    $serverErrorResponse = new Response(new GuzzleResponse(500));
+    $informationalResponse = new Response(100);
+    $successfulResponse = new Response(200);
+    $redirectionResponse = new Response(301);
+    $clientErrorResponse = new Response(404);
+    $serverErrorResponse = new Response(500);
 
     expect($informationalResponse->isInformational())->toBeTrue();
     expect($successfulResponse->ok())->toBeTrue();
@@ -57,7 +87,13 @@ test('Response status helper methods work correctly', function () {
 test('Response handles error gracefully', function () {
     $errorMessage = 'Something went wrong';
     $guzzleResponse = new GuzzleResponse(500, [], $errorMessage);
-    $response = new Response($guzzleResponse);
+    $response = new Response(
+        $guzzleResponse->getStatusCode(),
+        $guzzleResponse->getHeaders(),
+        (string) $guzzleResponse->getBody(),
+        $guzzleResponse->getProtocolVersion(),
+        $guzzleResponse->getReasonPhrase()
+    );
 
     expect($response->getStatusCode())->toBe(500);
     expect($response->text())->toBe($errorMessage);


### PR DESCRIPTION
## Purpose

This PR implements significant refactors to the `Fetch PHP` library, specifically addressing the transition from using Symfony's `Response` class to `guzzlehttp/psr7` for managing HTTP responses. This change improves compatibility and reduces the dependency footprint of the library. Additionally, the README has been updated to reflect these changes, ensuring that documentation is consistent with the current implementation. This update resolves compatibility issues reported in Laravel 10 projects and future-proofs the package with more flexible response handling.

**Related Issues**: [#issue-link] (if applicable)

## Approach

The primary focus of this change is refactoring the core `Response` class. The library now extends Guzzle's `Psr7\Response`, replacing the Symfony `Response` class. This adjustment simplifies the response handling process while maintaining the core functionality users expect from Fetch PHP. All available response methods (e.g., `json()`, `text()`, `statusText()`) have been adapted to ensure compatibility with this new architecture. Furthermore, the README was updated to document these changes clearly and concisely for developers using the library.

Key changes include:
- Refactoring of the `Response` class to extend `guzzlehttp/psr7` instead of Symfony's `Response`.
- Updated the HTTP request and response handling methods to ensure compatibility with PSR-7 standards.
- Improved error handling in both synchronous and asynchronous requests.
- Updated README to reflect the changes and provide examples with the updated response handling methods.

#### Open Questions and Pre-Merge TODOs

- [x] Ensure backward compatibility is maintained for projects using older versions of Symfony.
- [x] Update any tests relying on Symfony's `Response` to ensure compatibility with the new response class.
- [x] Ensure that all provided examples in the documentation reflect the current implementation.

## Learning

This update was based on research into transitioning from Symfony `Response` to PSR-7 standards using `guzzlehttp/psr7`. The goal was to simplify response handling and reduce dependencies, while maintaining the flexibility and feature set that Fetch PHP users are accustomed to. This required an in-depth understanding of both Symfony and Guzzle's HTTP components, as well as maintaining backward compatibility for existing users.