### PR TITLE
Add missing finalizeRequest() method to PerformsHttpRequests trait

### DIFF
--- a/src/Fetch/Concerns/PerformsHttpRequests.php
+++ b/src/Fetch/Concerns/PerformsHttpRequests.php
@@ -129,14 +129,17 @@ trait PerformsHttpRequests
      */
     protected function finalizeRequest(string $method, string $uri): ResponseInterface|PromiseInterface
     {
-        // Set the method in the options
-        $this->options['method'] = $method;
+        // Create a local copy of the options
+        $options = $this->options;
+
+        // Set the method in the local options
+        $options['method'] = $method;
 
         // Create a request object
         $request = $this->createRequest($method, $uri);
 
         // Apply any configured options to the request
-        $request = $this->applyOptionsToRequest($request);
+        $request = $this->applyOptionsToRequest($request, $options);
 
         // Send the request
         return $this->sendRequest($request);

--- a/src/Fetch/Concerns/PerformsHttpRequests.php
+++ b/src/Fetch/Concerns/PerformsHttpRequests.php
@@ -119,4 +119,26 @@ trait PerformsHttpRequests
     {
         return $this->finalizeRequest(Method::OPTIONS->value, $uri);
     }
+
+    /**
+     * Finalize and send a request with the specified method and URI.
+     *
+     * @param  string  $method  The HTTP method to use
+     * @param  string  $uri  The URI to request
+     * @return ResponseInterface|PromiseInterface The response or promise
+     */
+    protected function finalizeRequest(string $method, string $uri): ResponseInterface|PromiseInterface
+    {
+        // Set the method in the options
+        $this->options['method'] = $method;
+
+        // Create a request object
+        $request = $this->createRequest($method, $uri);
+
+        // Apply any configured options to the request
+        $request = $this->applyOptionsToRequest($request);
+
+        // Send the request
+        return $this->sendRequest($request);
+    }
 }


### PR DESCRIPTION
## Purpose

Fixes [#19](https://github.com/jerome/fetch-php/issues/<issue-number>) — calling `fetch()->get()` or other shortcut methods leads to a `Call to undefined method Fetch\Http\ClientHandler::finalizeRequest()` error.

The `PerformsHttpRequests` trait calls `finalizeRequest()`, but that method was never implemented.

## Approach

This PR adds the missing `finalizeRequest()` method to the `PerformsHttpRequests` trait. It creates and sends a request by applying the HTTP method and available options, and returns either a `ResponseInterface` or `PromiseInterface`, depending on sync/async mode.

## Learning

Reviewed the code path between `get()` → `finalizeRequest()` and the internal request building methods. Compared against `sendRequest()` flow to ensure consistency with `ClientHandler` expectations. No other internal method matched `finalizeRequest()` — this implementation aligns with the surrounding