### PR TITLE
Add middleware/interceptor system (v3.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Release Notes
 
-## [Unreleased](https://github.com/Thavarshan/fetch-php/compare/3.6.0...HEAD)
+## [Unreleased](https://github.com/Thavarshan/fetch-php/compare/3.7.0...HEAD)
+
+## [v3.7.0](https://github.com/Thavarshan/fetch-php/compare/3.6.0...3.7.0) - 2026-07-21
+
+### Added
+
+- **Middleware/Interceptor system** ([#39](https://github.com/Thavarshan/fetch-php/issues/39)) for wrapping the request/response lifecycle with cross-cutting concerns:
+  - `Fetch\Interfaces\Middleware` — `handle(RequestInterface $request, callable $next)` contract; plain callables with the same signature are accepted anywhere a middleware is.
+  - `Fetch\Http\MiddlewarePipeline` — composes an ordered, outermost-first stack into a single onion around the core request handler; transport-agnostic across sync responses and async promises.
+  - `Fetch\Concerns\ManagesMiddleware` — `addMiddleware()`, `middleware()`, `withoutMiddleware()`, and `getMiddleware()` on `ClientHandler` and `Client`, with priority ordering (highest runs first, stable on ties).
+  - Conditional configuration via `when()` / `unless()`.
+  - Middleware can modify the request, short-circuit with any PSR-7 response (coerced into a buffered `Response`), inspect/modify the response, and run in both synchronous and asynchronous modes. They sit outside the built-in mocking, caching, and retry logic.
+  - Built-in middleware: `Fetch\Middleware\AddHeadersMiddleware` and `Fetch\Middleware\LoggingMiddleware`.
 
 ## [v3.6.0](https://github.com/Thavarshan/fetch-php/compare/3.5.1...3.6.0) - 2026-07-21
 

--- a/CODE_MAP.md
+++ b/CODE_MAP.md
@@ -115,6 +115,18 @@ Key runtime behaviors:
 
 ---
 
+## Middleware Pipeline
+
+- `Fetch\Interfaces\Middleware` – `handle(RequestInterface $request, callable $next): ResponseInterface|PromiseInterface`. Plain callables with the same shape are accepted anywhere a middleware is.
+- `Fetch\Interfaces\MiddlewareAware` – handler/client contract: `addMiddleware()`, `middleware()`, `withoutMiddleware()`, `getMiddleware()`, `when()`, `unless()`.
+- `Fetch\Concerns\ManagesMiddleware` – trait mixed into `ClientHandler`. Stores middleware with a priority + insertion sequence; `resolveMiddleware()` orders them highest-priority-first (stable on ties). `runThroughMiddleware()` builds the pipeline around a core handler.
+- `Fetch\Http\MiddlewarePipeline` – composes an ordered (outermost-first) list into a single callable onion via `array_reduce`; supports both `Middleware` objects and callables and is transport-agnostic (passes through sync responses or promises).
+- Integration: `PerformsHttpRequests::sendRequest()` builds a PSR-7 request from the resolved method/URI/headers/body, runs it through the pipeline, and folds middleware changes back into the Guzzle options before the built-in mock/cache/retry/execute core (`executeCore`). Middleware therefore sit outside caching and can short-circuit; a foreign PSR-7 response returned by a middleware is coerced into a buffered `Fetch\Http\Response`.
+- `Client` mirrors the middleware methods, delegating to its handler.
+- Built-in middleware (`src/Fetch/Middleware`): `AddHeadersMiddleware` (inject/override headers) and `LoggingMiddleware` (PSR-3 request/response logging with a correlation id; works sync and async).
+
+---
+
 ## Support Services
 
 - `Fetch\Support\RequestOptions`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Full documentation can be found [here](https://fetch-php.thavarshan.com/)
 - **Fluent Interface**: Build requests with a clean, chainable API
 - **Built on Guzzle**: Benefit from Guzzle's robust functionality with a more elegant API
 - **Streaming & Server-Sent Events**: Consume response bodies incrementally (`response.body`-style) and parse `text/event-stream` responses — ideal for streaming LLM APIs and live feeds
+- **Middleware Pipeline**: PSR-7-based middleware/interceptors for cross-cutting concerns (auth, logging, versioning) with priority ordering and conditional application
 - **Retry Mechanics**: Configurable retry logic with exponential backoff for transient failures
 - **RFC 7234 HTTP Caching**: Full caching support with ETag/Last-Modified revalidation, stale-while-revalidate, and stale-if-error
 - **Connection Pooling**: Reuse TCP connections across requests with global connection pool and DNS caching

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -211,6 +211,10 @@ export default defineConfig({
                             text: "Streaming & Server-Sent Events",
                             link: "/guide/streaming",
                         },
+                        {
+                            text: "Middleware & Interceptors",
+                            link: "/guide/middleware",
+                        },
                         { text: "File Uploads", link: "/guide/file-uploads" },
                         {
                             text: "Custom Clients",

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -1,0 +1,141 @@
+---
+title: Middleware & Interceptors
+description: Wrap the request/response lifecycle with a PSR-7 middleware pipeline for auth, logging, versioning, and other cross-cutting concerns.
+---
+
+# Middleware & Interceptors
+
+Middleware let you wrap the request/response lifecycle without touching every call site — the PHP equivalent of JavaScript fetch interceptors or Laravel's HTTP middleware. Each middleware receives the outgoing PSR-7 request and a `$next` callable representing the rest of the pipeline, so it can:
+
+- modify the request before calling `$next($request)`;
+- short-circuit by returning a response without calling `$next`;
+- inspect or modify the response that comes back;
+- catch and handle errors thrown further down the pipeline.
+
+Middleware sit **outside** the built-in mocking, caching, and retry logic, so they run first and can short-circuit before any of that work happens.
+
+## Writing middleware
+
+Implement `Fetch\Interfaces\Middleware`:
+
+```php
+use Fetch\Interfaces\Middleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+final class AuthMiddleware implements Middleware
+{
+    public function __construct(private TokenManager $tokens) {}
+
+    public function handle(RequestInterface $request, callable $next): ResponseInterface|PromiseInterface
+    {
+        $request = $request->withHeader('Authorization', 'Bearer ' . $this->tokens->get());
+
+        return $next($request);
+    }
+}
+```
+
+Trivial middleware can be plain callables with the same signature — no class required:
+
+```php
+$client->addMiddleware(fn ($request, $next) => $next($request->withHeader('X-Trace-ID', uniqid())));
+```
+
+## Registering middleware
+
+```php
+use Fetch\Middleware\AddHeadersMiddleware;
+use Fetch\Middleware\LoggingMiddleware;
+
+fetch_client()
+    ->addMiddleware(new AuthMiddleware($tokens))
+    ->addMiddleware(new LoggingMiddleware($logger))
+    ->get('https://api.example.com/users');
+```
+
+Replace the whole stack with `middleware()`, and remove middleware with `withoutMiddleware()`:
+
+```php
+$client->middleware([
+    new AuthMiddleware($tokens),
+    [new LoggingMiddleware($logger), 100], // [middleware, priority]
+]);
+
+$client->withoutMiddleware(LoggingMiddleware::class); // remove by class
+$client->withoutMiddleware();                          // clear all
+```
+
+Middleware registered on the global client (`fetch_client()`) also apply to the `fetch()`, `get()`, `post()`, … helpers, since they share the same handler.
+
+## Ordering with priority
+
+Higher priority runs first (outermost). Middleware with equal priority run in the order they were added.
+
+```php
+$client
+    ->addMiddleware($rateLimiter, priority: 100) // runs first
+    ->addMiddleware($auth, priority: 50)
+    ->addMiddleware($logger);                    // priority 0, runs last
+```
+
+## Conditional registration
+
+`when()` and `unless()` apply configuration only when a condition holds. The condition may be a boolean or a callable resolved with the handler:
+
+```php
+$client
+    ->when($isProduction, fn ($c) => $c->addMiddleware(new SecurityMiddleware()))
+    ->unless($isLocal, fn ($c) => $c->addMiddleware(new MetricsMiddleware()));
+```
+
+## Short-circuiting
+
+Return a response without calling `$next` to skip the actual request — useful for caching layers, circuit breakers, or canned responses:
+
+```php
+$client->addMiddleware(function ($request, $next) use ($cache) {
+    if ($hit = $cache->get((string) $request->getUri())) {
+        return $hit; // any PSR-7 response; wrapped into a Fetch response automatically
+    }
+
+    return $next($request);
+});
+```
+
+## Modifying the response
+
+```php
+$client->addMiddleware(function ($request, $next) {
+    $response = $next($request);
+
+    return $response->withHeader('X-Processed-By', 'fetch-php');
+});
+```
+
+## Async middleware
+
+In asynchronous mode (`->async()`), `$next($request)` returns a `React\Promise\PromiseInterface` rather than a response. Middleware that need the response must chain off the promise instead of inspecting it directly:
+
+```php
+final class AsyncCacheMiddleware implements Middleware
+{
+    public function handle(RequestInterface $request, callable $next): ResponseInterface|PromiseInterface
+    {
+        return $next($request)->then(function ($response) {
+            // inspect/annotate the resolved response
+            return $response;
+        });
+    }
+}
+```
+
+The built-in `LoggingMiddleware` handles both modes transparently.
+
+## Built-in middleware
+
+| Middleware | Purpose |
+| ---------- | ------- |
+| `Fetch\Middleware\AddHeadersMiddleware` | Add or override a fixed set of headers (API versioning, tenant IDs, …). Pass `overwrite: false` to only fill in absent headers. |
+| `Fetch\Middleware\LoggingMiddleware` | Log the request/response lifecycle to a PSR-3 logger with a per-request correlation ID; works synchronously and asynchronously. |

--- a/src/Fetch/Concerns/ManagesMiddleware.php
+++ b/src/Fetch/Concerns/ManagesMiddleware.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fetch\Concerns;
+
+use Fetch\Http\MiddlewarePipeline;
+use Fetch\Interfaces\Middleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+/**
+ * Adds a middleware pipeline to a client handler.
+ *
+ * Middleware are stored with a priority and an insertion sequence so the stack
+ * has a stable, predictable order: higher priority runs first (outermost), and
+ * ties break by insertion order. The trait also provides fluent conditional
+ * configuration (`when`/`unless`) in the spirit of Laravel's Conditionable.
+ */
+trait ManagesMiddleware
+{
+    /**
+     * @var array<int, array{middleware: Middleware|callable, priority: int, seq: int}>
+     */
+    protected array $middlewareStack = [];
+
+    /**
+     * Monotonic counter used to keep equal-priority middleware stably ordered.
+     */
+    protected int $middlewareSequence = 0;
+
+    /**
+     * Append a middleware to the stack.
+     *
+     * @param  Middleware|callable(RequestInterface, callable): mixed  $middleware
+     * @return $this
+     */
+    public function addMiddleware(Middleware|callable $middleware, int $priority = 0): static
+    {
+        $this->middlewareStack[] = [
+            'middleware' => $middleware,
+            'priority' => $priority,
+            'seq' => $this->middlewareSequence++,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Replace the entire middleware stack.
+     *
+     * @param  array<int, Middleware|callable|array{0: Middleware|callable, 1?: int}>  $middleware
+     * @return $this
+     */
+    public function middleware(array $middleware): static
+    {
+        $this->middlewareStack = [];
+        $this->middlewareSequence = 0;
+
+        foreach ($middleware as $entry) {
+            if (is_array($entry)) {
+                $this->addMiddleware($entry[0], $entry[1] ?? 0);
+            } else {
+                $this->addMiddleware($entry);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove middleware from the stack.
+     *
+     * With no argument, clears the stack. With a class-string, removes every
+     * middleware that is an instance of that class.
+     *
+     * @param  class-string|null  $class
+     * @return $this
+     */
+    public function withoutMiddleware(?string $class = null): static
+    {
+        if ($class === null) {
+            $this->middlewareStack = [];
+            $this->middlewareSequence = 0;
+
+            return $this;
+        }
+
+        $this->middlewareStack = array_values(array_filter(
+            $this->middlewareStack,
+            fn (array $entry): bool => ! ($entry['middleware'] instanceof $class),
+        ));
+
+        return $this;
+    }
+
+    /**
+     * Whether any middleware is registered.
+     */
+    public function hasMiddleware(): bool
+    {
+        return $this->middlewareStack !== [];
+    }
+
+    /**
+     * Get the resolved middleware stack in execution order (outermost first).
+     *
+     * @return array<int, Middleware|callable>
+     */
+    public function getMiddleware(): array
+    {
+        return $this->resolveMiddleware();
+    }
+
+    /**
+     * Apply the given callback to the handler when the condition is truthy.
+     *
+     * @param  mixed  $condition  A boolean, or a callable resolved with the handler.
+     * @param  callable(static, mixed): mixed  $callback
+     * @param  callable(static, mixed): mixed|null  $default
+     * @return $this
+     */
+    public function when(mixed $condition, callable $callback, ?callable $default = null): static
+    {
+        $value = is_callable($condition) ? $condition($this) : $condition;
+
+        if ($value) {
+            $callback($this, $value);
+        } elseif ($default !== null) {
+            $default($this, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the given callback to the handler when the condition is falsy.
+     *
+     * @param  mixed  $condition  A boolean, or a callable resolved with the handler.
+     * @param  callable(static, mixed): mixed  $callback
+     * @param  callable(static, mixed): mixed|null  $default
+     * @return $this
+     */
+    public function unless(mixed $condition, callable $callback, ?callable $default = null): static
+    {
+        $value = is_callable($condition) ? $condition($this) : $condition;
+
+        if (! $value) {
+            $callback($this, $value);
+        } elseif ($default !== null) {
+            $default($this, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Resolve the stack into an ordered list of middleware.
+     *
+     * @return array<int, Middleware|callable>
+     */
+    protected function resolveMiddleware(): array
+    {
+        if ($this->middlewareStack === []) {
+            return [];
+        }
+
+        $entries = $this->middlewareStack;
+
+        usort(
+            $entries,
+            fn (array $a, array $b): int => ($b['priority'] <=> $a['priority']) ?: ($a['seq'] <=> $b['seq']),
+        );
+
+        return array_map(static fn (array $entry) => $entry['middleware'], $entries);
+    }
+
+    /**
+     * Run a request through the middleware pipeline around the given core handler.
+     *
+     * @param  callable(RequestInterface): (ResponseInterface|PromiseInterface)  $core
+     */
+    protected function runThroughMiddleware(RequestInterface $request, callable $core): ResponseInterface|PromiseInterface
+    {
+        $resolved = $this->resolveMiddleware();
+
+        if ($resolved === []) {
+            return $core($request);
+        }
+
+        return (new MiddlewarePipeline($resolved))->handle($request, $core);
+    }
+}

--- a/src/Fetch/Concerns/PerformsHttpRequests.php
+++ b/src/Fetch/Concerns/PerformsHttpRequests.php
@@ -19,6 +19,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use Matrix\Exceptions\AsyncException;
+use Psr\Http\Message\RequestInterface;
 use React\Promise\PromiseInterface;
 use RuntimeException;
 
@@ -243,6 +244,141 @@ trait PerformsHttpRequests
         // Start profiling once for this request path
         $requestId = $this->startProfiling($methodStr, $fullUri);
 
+        // Wrap the send in the middleware pipeline when any middleware is
+        // registered. Middleware sit outside the built-in mock/cache/retry
+        // logic, so they can inspect, modify, or short-circuit the request.
+        $resolvedMiddleware = method_exists($this, 'resolveMiddleware')
+            ? $this->resolveMiddleware()
+            : [];
+
+        if ($resolvedMiddleware === []) {
+            return $this->executeCore($methodStr, $fullUri, $guzzleOptions, $context, $startTime, $startMemory, $requestId);
+        }
+
+        [$psrRequest, $seedBody] = $this->buildMiddlewareRequest($methodStr, $fullUri, $guzzleOptions);
+
+        $core = function (RequestInterface $request) use ($guzzleOptions, $seedBody, $context, $startTime, $startMemory, $requestId): ResponseInterface|PromiseInterface {
+            $mergedOptions = $this->mergeRequestIntoOptions($request, $guzzleOptions, $seedBody);
+
+            return $this->executeCore(
+                $request->getMethod(),
+                (string) $request->getUri(),
+                $mergedOptions,
+                $context,
+                $startTime,
+                $startMemory,
+                $requestId,
+            );
+        };
+
+        return $this->coerceMiddlewareResult($this->runThroughMiddleware($psrRequest, $core));
+    }
+
+    /**
+     * Sends an HTTP request with the specified parameters.
+     *
+     * @param  string|Method  $method  HTTP method (e.g., GET, POST)
+     * @param  string  $uri  URI to send the request to
+     * @param  mixed  $body  Request body
+     * @param  string|ContentType  $contentType  Content type of the request
+     * @param  array<string, mixed>  $options  Additional request options
+     * @return Response|PromiseInterface Response or promise
+     */
+    public function request(
+        string|Method $method,
+        string $uri,
+        mixed $body = null,
+        string|ContentType $contentType = ContentType::JSON,
+        array $options = [],
+    ): Response|PromiseInterface {
+        $mergedOptions = RequestOptions::merge($this->options, $options);
+
+        if ($body !== null) {
+            $mergedOptions = $this->applyBodyOptions($mergedOptions, $body, $contentType);
+        }
+
+        return $this->sendRequest($method, $uri, $mergedOptions);
+    }
+
+    /**
+     * Get the effective timeout for the request.
+     *
+     * Supports per-request timeout via RequestContext, with handler defaults as fallback.
+     *
+     * @param  RequestContext|null  $context  Optional request context for per-request override
+     * @return int The timeout in seconds
+     */
+    public function getEffectiveTimeout(?RequestContext $context = null): int
+    {
+        // First check RequestContext for per-request override
+        if ($context !== null) {
+            return $context->getTimeout();
+        }
+
+        // Next check options array
+        if (isset($this->options['timeout']) && is_int($this->options['timeout'])) {
+            return $this->options['timeout'];
+        }
+
+        // Then check explicitly set timeout property
+        if (isset($this->timeout) && is_int($this->timeout)) {
+            return $this->timeout;
+        }
+
+        // Fall back to default
+        return self::DEFAULT_TIMEOUT;
+    }
+
+    /**
+     * Normalize whatever the middleware pipeline returns into a Fetch response.
+     *
+     * Middleware may short-circuit with any PSR-7 response; those are wrapped in
+     * a buffered {@see Response} so the public contract always yields a Fetch
+     * response (or a promise of one).
+     */
+    protected function coerceMiddlewareResult(\Psr\Http\Message\ResponseInterface|PromiseInterface $result): ResponseInterface|PromiseInterface
+    {
+        if ($result instanceof PromiseInterface) {
+            return $result->then(fn ($response) => $this->coerceResponseValue($response));
+        }
+
+        return $this->coerceResponseValue($result);
+    }
+
+    /**
+     * Wrap a foreign PSR-7 response in a Fetch response, leaving Fetch
+     * responses untouched.
+     */
+    protected function coerceResponseValue(mixed $response): mixed
+    {
+        if ($response instanceof ResponseInterface) {
+            return $response;
+        }
+
+        if ($response instanceof \Psr\Http\Message\ResponseInterface) {
+            return Response::createFromBase($response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Execute the built-in send pipeline: mocking, caching, and the actual
+     * synchronous or asynchronous request. This is the core handler wrapped by
+     * any registered middleware.
+     *
+     * @param  array<string, mixed>  $guzzleOptions
+     * @return ResponseInterface|PromiseInterface The response or promise
+     */
+    protected function executeCore(
+        string $methodStr,
+        string $fullUri,
+        array $guzzleOptions,
+        RequestContext $context,
+        float $startTime,
+        int $startMemory,
+        ?string $requestId,
+    ): ResponseInterface|PromiseInterface {
         // Check for mock response first (if HandlesMocking trait is available)
         if (method_exists($this, 'handleMockRequest')) {
             $mockResponse = $this->handleMockRequest($methodStr, $fullUri, $guzzleOptions);
@@ -339,58 +475,94 @@ trait PerformsHttpRequests
     }
 
     /**
-     * Sends an HTTP request with the specified parameters.
+     * Build the PSR-7 request handed to the middleware pipeline.
      *
-     * @param  string|Method  $method  HTTP method (e.g., GET, POST)
-     * @param  string  $uri  URI to send the request to
-     * @param  mixed  $body  Request body
-     * @param  string|ContentType  $contentType  Content type of the request
-     * @param  array<string, mixed>  $options  Additional request options
-     * @return Response|PromiseInterface Response or promise
+     * The request carries the resolved method, absolute URI, and headers, plus
+     * a best-effort serialization of the body so middleware can read it. The
+     * seeded body string is returned alongside so the core handler can detect
+     * whether a middleware replaced it.
+     *
+     * @param  array<string, mixed>  $guzzleOptions
+     * @return array{0: RequestInterface, 1: string|null}
      */
-    public function request(
-        string|Method $method,
-        string $uri,
-        mixed $body = null,
-        string|ContentType $contentType = ContentType::JSON,
-        array $options = [],
-    ): Response|PromiseInterface {
-        $mergedOptions = RequestOptions::merge($this->options, $options);
+    protected function buildMiddlewareRequest(string $method, string $uri, array $guzzleOptions): array
+    {
+        $headers = $guzzleOptions['headers'] ?? [];
+        $seedBody = $this->encodeSeedBody($guzzleOptions);
 
-        if ($body !== null) {
-            $mergedOptions = $this->applyBodyOptions($mergedOptions, $body, $contentType);
-        }
+        $request = new GuzzleRequest($method, $uri, $headers, $seedBody ?? '');
 
-        return $this->sendRequest($method, $uri, $mergedOptions);
+        return [$request, $seedBody];
     }
 
     /**
-     * Get the effective timeout for the request.
+     * Serialize the outgoing body to a string for middleware inspection.
      *
-     * Supports per-request timeout via RequestContext, with handler defaults as fallback.
+     * Returns null when there is no representable body (e.g. multipart uploads,
+     * which Guzzle streams itself, or no body at all).
      *
-     * @param  RequestContext|null  $context  Optional request context for per-request override
-     * @return int The timeout in seconds
+     * @param  array<string, mixed>  $guzzleOptions
      */
-    public function getEffectiveTimeout(?RequestContext $context = null): int
+    protected function encodeSeedBody(array $guzzleOptions): ?string
     {
-        // First check RequestContext for per-request override
-        if ($context !== null) {
-            return $context->getTimeout();
+        if (array_key_exists('body', $guzzleOptions) && is_string($guzzleOptions['body'])) {
+            return $guzzleOptions['body'];
         }
 
-        // Next check options array
-        if (isset($this->options['timeout']) && is_int($this->options['timeout'])) {
-            return $this->options['timeout'];
+        if (isset($guzzleOptions['json'])) {
+            try {
+                return json_encode($guzzleOptions['json'], JSON_THROW_ON_ERROR);
+            } catch (\JsonException) {
+                return null;
+            }
         }
 
-        // Then check explicitly set timeout property
-        if (isset($this->timeout) && is_int($this->timeout)) {
-            return $this->timeout;
+        if (isset($guzzleOptions['form_params']) && is_array($guzzleOptions['form_params'])) {
+            return http_build_query($guzzleOptions['form_params'], '', '&');
         }
 
-        // Fall back to default
-        return self::DEFAULT_TIMEOUT;
+        return null;
+    }
+
+    /**
+     * Fold any middleware changes to the request back into the Guzzle options.
+     *
+     * Headers from the (possibly modified) request replace the outgoing header
+     * set. If a middleware replaced the body, it is sent verbatim and the
+     * structured body keys are dropped so they do not conflict.
+     *
+     * @param  array<string, mixed>  $guzzleOptions
+     * @return array<string, mixed>
+     */
+    protected function mergeRequestIntoOptions(RequestInterface $request, array $guzzleOptions, ?string $seedBody): array
+    {
+        $headers = [];
+        foreach ($request->getHeaders() as $name => $values) {
+            $headers[$name] = count($values) === 1 ? $values[0] : $values;
+        }
+
+        if ($headers !== []) {
+            $guzzleOptions['headers'] = $headers;
+        }
+
+        // The URI is already absolute; ensure no base_uri is re-applied.
+        unset($guzzleOptions['base_uri']);
+
+        $body = (string) $request->getBody();
+
+        if ($seedBody !== null && $body !== $seedBody) {
+            // A middleware rewrote the body: send it raw.
+            unset($guzzleOptions['json'], $guzzleOptions['form_params'], $guzzleOptions['multipart']);
+            $guzzleOptions['body'] = $body;
+        } elseif ($seedBody === null && $body !== ''
+            && ! isset($guzzleOptions['multipart'])
+            && ! isset($guzzleOptions['form_params'])
+            && ! isset($guzzleOptions['json'])) {
+            // No structured body existed, but a middleware added one.
+            $guzzleOptions['body'] = $body;
+        }
+
+        return $guzzleOptions;
     }
 
     /**

--- a/src/Fetch/Http/Client.php
+++ b/src/Fetch/Http/Client.php
@@ -10,6 +10,7 @@ use Fetch\Exceptions\ClientException;
 use Fetch\Exceptions\NetworkException;
 use Fetch\Exceptions\RequestException;
 use Fetch\Interfaces\ClientHandler as ClientHandlerInterface;
+use Fetch\Interfaces\Middleware;
 use Fetch\Interfaces\Response as ResponseInterface;
 use Fetch\Interfaces\StreamedResponse as StreamedResponseInterface;
 use GuzzleHttp\ClientInterface as GuzzleClientInterface;
@@ -391,6 +392,95 @@ class Client implements ClientInterface, LoggerAwareInterface
         string|Method $method = Method::GET,
     ): EventSource {
         return $this->handler->withOptions($options ?? [])->sse($method, $url);
+    }
+
+    /**
+     * Append a middleware to the underlying handler's stack.
+     *
+     * @param  Middleware|callable(\Psr\Http\Message\RequestInterface, callable): mixed  $middleware
+     * @return $this
+     */
+    public function addMiddleware(Middleware|callable $middleware, int $priority = 0): self
+    {
+        $this->handler->addMiddleware($middleware, $priority);
+
+        return $this;
+    }
+
+    /**
+     * Replace the underlying handler's middleware stack.
+     *
+     * @param  array<int, Middleware|callable|array{0: Middleware|callable, 1?: int}>  $middleware
+     * @return $this
+     */
+    public function middleware(array $middleware): self
+    {
+        $this->handler->middleware($middleware);
+
+        return $this;
+    }
+
+    /**
+     * Remove middleware from the underlying handler's stack.
+     *
+     * @param  class-string|null  $class
+     * @return $this
+     */
+    public function withoutMiddleware(?string $class = null): self
+    {
+        $this->handler->withoutMiddleware($class);
+
+        return $this;
+    }
+
+    /**
+     * Get the resolved middleware stack in execution order.
+     *
+     * @return array<int, Middleware|callable>
+     */
+    public function getMiddleware(): array
+    {
+        return $this->handler->getMiddleware();
+    }
+
+    /**
+     * Apply the callback to the client when the condition is truthy.
+     *
+     * @param  callable(self, mixed): mixed  $callback
+     * @param  callable(self, mixed): mixed|null  $default
+     * @return $this
+     */
+    public function when(mixed $condition, callable $callback, ?callable $default = null): self
+    {
+        $value = is_callable($condition) ? $condition($this) : $condition;
+
+        if ($value) {
+            $callback($this, $value);
+        } elseif ($default !== null) {
+            $default($this, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the callback to the client when the condition is falsy.
+     *
+     * @param  callable(self, mixed): mixed  $callback
+     * @param  callable(self, mixed): mixed|null  $default
+     * @return $this
+     */
+    public function unless(mixed $condition, callable $callback, ?callable $default = null): self
+    {
+        $value = is_callable($condition) ? $condition($this) : $condition;
+
+        if (! $value) {
+            $callback($this, $value);
+        } elseif ($default !== null) {
+            $default($this, $value);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Fetch/Http/ClientHandler.php
+++ b/src/Fetch/Http/ClientHandler.php
@@ -11,6 +11,7 @@ use Fetch\Concerns\HandlesMocking;
 use Fetch\Concerns\HandlesUris;
 use Fetch\Concerns\ManagesConnectionPool;
 use Fetch\Concerns\ManagesDebugAndProfiling;
+use Fetch\Concerns\ManagesMiddleware;
 use Fetch\Concerns\ManagesPromises;
 use Fetch\Concerns\ManagesRetries;
 use Fetch\Concerns\PerformsHttpRequests;
@@ -39,6 +40,7 @@ class ClientHandler implements ClientHandlerInterface
     use HandlesUris;
     use ManagesConnectionPool;
     use ManagesDebugAndProfiling;
+    use ManagesMiddleware;
     use ManagesPromises;
     use ManagesRetries;
     use PerformsHttpRequests;

--- a/src/Fetch/Http/MiddlewarePipeline.php
+++ b/src/Fetch/Http/MiddlewarePipeline.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fetch\Http;
+
+use Fetch\Interfaces\Middleware;
+use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+/**
+ * Composes an ordered list of middleware into a single callable pipeline.
+ *
+ * The list is treated as outermost-first: the first middleware wraps the
+ * second, which wraps the third, and so on, with the core request handler at
+ * the centre. Both {@see Middleware} instances and plain callables with the
+ * signature `fn(RequestInterface $request, callable $next)` are supported.
+ *
+ * The pipeline is transport-agnostic: whatever the core handler returns (a
+ * {@see ResponseInterface} synchronously, or a {@see PromiseInterface} in async
+ * mode) flows back out through the middleware unchanged.
+ */
+final class MiddlewarePipeline
+{
+    /**
+     * @param  array<int, Middleware|callable>  $middleware  Ordered outermost-first.
+     */
+    public function __construct(
+        private readonly array $middleware,
+    ) {}
+
+    /**
+     * Run the request through the middleware stack and core handler.
+     *
+     * @param  callable(RequestInterface): (ResponseInterface|PromiseInterface)  $core
+     */
+    public function handle(RequestInterface $request, callable $core): ResponseInterface|PromiseInterface
+    {
+        $pipeline = array_reduce(
+            array_reverse($this->middleware),
+            fn (callable $next, Middleware|callable $middleware): callable => fn (RequestInterface $req): ResponseInterface|PromiseInterface => $this->call($middleware, $req, $next),
+            $core,
+        );
+
+        return $pipeline($request);
+    }
+
+    /**
+     * Invoke a single middleware entry.
+     *
+     * @param  callable(RequestInterface): (ResponseInterface|PromiseInterface)  $next
+     */
+    private function call(Middleware|callable $middleware, RequestInterface $request, callable $next): ResponseInterface|PromiseInterface
+    {
+        if ($middleware instanceof Middleware) {
+            return $middleware->handle($request, $next);
+        }
+
+        $result = $middleware($request, $next);
+
+        if (! $result instanceof ResponseInterface && ! $result instanceof PromiseInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'Callable middleware must return a %s or %s, got %s.',
+                ResponseInterface::class,
+                PromiseInterface::class,
+                get_debug_type($result),
+            ));
+        }
+
+        return $result;
+    }
+}

--- a/src/Fetch/Interfaces/ClientHandler.php
+++ b/src/Fetch/Interfaces/ClientHandler.php
@@ -6,7 +6,7 @@ namespace Fetch\Interfaces;
 
 use GuzzleHttp\ClientInterface;
 
-interface ClientHandler extends CacheableRequestHandler, DebuggableHandler, HttpClientAware, PoolAwareHandler, PromiseHandler, RequestConfigurator, RequestExecutor, RetryableHandler
+interface ClientHandler extends CacheableRequestHandler, DebuggableHandler, HttpClientAware, MiddlewareAware, PoolAwareHandler, PromiseHandler, RequestConfigurator, RequestExecutor, RetryableHandler
 {
     /**
      * @return array<string, mixed>

--- a/src/Fetch/Interfaces/Middleware.php
+++ b/src/Fetch/Interfaces/Middleware.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fetch\Interfaces;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+/**
+ * A request/response middleware in the Fetch PHP pipeline.
+ *
+ * Middleware wrap the request lifecycle in an onion: each one receives the
+ * outgoing PSR-7 request and a `$next` callable representing the rest of the
+ * pipeline (inner middleware plus the core request dispatch). A middleware may:
+ *
+ * - inspect or modify the request before calling `$next($request)`;
+ * - short-circuit by returning a response without calling `$next`;
+ * - inspect or modify the response returned by `$next`;
+ * - catch and handle errors thrown further down the pipeline.
+ *
+ * In synchronous mode `$next` returns a {@see ResponseInterface}. In async mode
+ * it returns a {@see PromiseInterface}; middleware that need the response must
+ * chain off the promise (e.g. `->then(...)`) rather than inspecting it directly.
+ *
+ * Plain callables with the signature `fn(RequestInterface $request, callable $next)`
+ * are also accepted anywhere a Middleware is, so trivial middleware need not
+ * declare a class.
+ */
+interface Middleware
+{
+    /**
+     * Handle the request and produce a response (or a promise of one).
+     *
+     * @param  RequestInterface  $request  The outgoing request.
+     * @param  callable(RequestInterface): (ResponseInterface|PromiseInterface)  $next  The rest of the pipeline.
+     */
+    public function handle(RequestInterface $request, callable $next): ResponseInterface|PromiseInterface;
+}

--- a/src/Fetch/Interfaces/MiddlewareAware.php
+++ b/src/Fetch/Interfaces/MiddlewareAware.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fetch\Interfaces;
+
+interface MiddlewareAware
+{
+    /**
+     * Append a middleware to the stack.
+     *
+     * Higher-priority middleware run first (outermost). Middleware with equal
+     * priority run in the order they were added.
+     *
+     * @param  Middleware|callable(\Psr\Http\Message\RequestInterface, callable): mixed  $middleware
+     */
+    public function addMiddleware(Middleware|callable $middleware, int $priority = 0): self;
+
+    /**
+     * Replace the entire middleware stack.
+     *
+     * Each entry is either a middleware (object or callable) or a
+     * `[$middleware, $priority]` pair.
+     *
+     * @param  array<int, Middleware|callable|array{0: Middleware|callable, 1?: int}>  $middleware
+     */
+    public function middleware(array $middleware): self;
+
+    /**
+     * Remove middleware from the stack.
+     *
+     * With no argument, clears the stack. With a class-string, removes every
+     * middleware that is an instance of that class.
+     *
+     * @param  class-string|null  $class
+     */
+    public function withoutMiddleware(?string $class = null): self;
+
+    /**
+     * Get the resolved middleware stack in execution order (outermost first).
+     *
+     * @return array<int, Middleware|callable>
+     */
+    public function getMiddleware(): array;
+
+    /**
+     * Apply the given callback to the handler when the condition is truthy.
+     *
+     * @param  mixed  $condition  A boolean, or a callable resolved with the handler.
+     * @param  callable(self, mixed): mixed  $callback
+     * @param  callable(self, mixed): mixed|null  $default
+     */
+    public function when(mixed $condition, callable $callback, ?callable $default = null): self;
+
+    /**
+     * Apply the given callback to the handler when the condition is falsy.
+     *
+     * @param  mixed  $condition  A boolean, or a callable resolved with the handler.
+     * @param  callable(self, mixed): mixed  $callback
+     * @param  callable(self, mixed): mixed|null  $default
+     */
+    public function unless(mixed $condition, callable $callback, ?callable $default = null): self;
+}

--- a/src/Fetch/Middleware/AddHeadersMiddleware.php
+++ b/src/Fetch/Middleware/AddHeadersMiddleware.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fetch\Middleware;
+
+use Fetch\Interfaces\Middleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+/**
+ * Adds (or overrides) a fixed set of headers on every outgoing request.
+ *
+ * Useful for cross-cutting concerns such as API versioning, tenant isolation,
+ * or a static correlation prefix:
+ *
+ * ```php
+ * $client->addMiddleware(new AddHeadersMiddleware([
+ *     'X-Api-Version' => '2.1',
+ *     'X-Tenant-ID'   => $tenantId,
+ * ]));
+ * ```
+ */
+final class AddHeadersMiddleware implements Middleware
+{
+    /**
+     * @param  array<string, string|string[]>  $headers  Header name => value(s).
+     * @param  bool  $overwrite  Replace existing headers (true) or only add when absent (false).
+     */
+    public function __construct(
+        private readonly array $headers,
+        private readonly bool $overwrite = true,
+    ) {}
+
+    public function handle(RequestInterface $request, callable $next): ResponseInterface|PromiseInterface
+    {
+        foreach ($this->headers as $name => $value) {
+            if (! $this->overwrite && $request->hasHeader($name)) {
+                continue;
+            }
+
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Fetch/Middleware/LoggingMiddleware.php
+++ b/src/Fetch/Middleware/LoggingMiddleware.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fetch\Middleware;
+
+use Fetch\Interfaces\Middleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use React\Promise\PromiseInterface;
+
+/**
+ * Logs the request/response lifecycle to a PSR-3 logger.
+ *
+ * A correlation ID is generated per request, attached as a header, and included
+ * in both log entries so a request and its response can be tied together. Works
+ * transparently in both synchronous and asynchronous modes.
+ */
+final class LoggingMiddleware implements Middleware
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly string $level = LogLevel::INFO,
+        private readonly string $correlationHeader = 'X-Correlation-ID',
+    ) {}
+
+    public function handle(RequestInterface $request, callable $next): ResponseInterface|PromiseInterface
+    {
+        $correlationId = $this->generateCorrelationId();
+        $request = $request->withHeader($this->correlationHeader, $correlationId);
+
+        $start = microtime(true);
+
+        $this->logger->log($this->level, 'HTTP request started', [
+            'correlation_id' => $correlationId,
+            'method' => $request->getMethod(),
+            'uri' => (string) $request->getUri(),
+        ]);
+
+        $result = $next($request);
+
+        if ($result instanceof PromiseInterface) {
+            return $result->then(function (ResponseInterface $response) use ($correlationId, $start): ResponseInterface {
+                $this->logResponse($response, $correlationId, $start);
+
+                return $response;
+            });
+        }
+
+        $this->logResponse($result, $correlationId, $start);
+
+        return $result;
+    }
+
+    private function logResponse(ResponseInterface $response, string $correlationId, float $start): void
+    {
+        $this->logger->log($this->level, 'HTTP request completed', [
+            'correlation_id' => $correlationId,
+            'status_code' => $response->getStatusCode(),
+            'duration_ms' => round((microtime(true) - $start) * 1000, 2),
+        ]);
+    }
+
+    private function generateCorrelationId(): string
+    {
+        return bin2hex(random_bytes(8));
+    }
+}

--- a/tests/Integration/MiddlewareTest.php
+++ b/tests/Integration/MiddlewareTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use Fetch\Http\ClientHandler;
+use Fetch\Middleware\AddHeadersMiddleware;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use React\Promise\PromiseInterface;
+
+use function Matrix\Support\await;
+
+class MiddlewareTest extends TestCase
+{
+    private MockHandler $mock;
+
+    private function handler(array $responses): ClientHandler
+    {
+        $this->mock = new MockHandler($responses);
+        $stack = HandlerStack::create($this->mock);
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+
+        return (new ClientHandler)->setHttpClient($guzzle);
+    }
+
+    public function test_middleware_injects_header_into_real_request(): void
+    {
+        $handler = $this->handler([new PsrResponse(200, [], 'ok')]);
+        $handler->addMiddleware(new AddHeadersMiddleware(['X-Api-Version' => '2.1']));
+
+        $handler->get('https://example.com/users');
+
+        $this->assertSame('2.1', $this->mock->getLastRequest()->getHeaderLine('X-Api-Version'));
+    }
+
+    public function test_middleware_can_short_circuit_without_hitting_transport(): void
+    {
+        // No responses queued: if the transport is touched, MockHandler throws.
+        $handler = $this->handler([]);
+        $handler->addMiddleware(
+            fn (RequestInterface $request, callable $next) => new PsrResponse(418, [], 'cached')
+        );
+
+        $response = $handler->get('https://example.com/teapot');
+
+        $this->assertSame(418, $response->getStatusCode());
+        $this->assertNull($this->mock->getLastRequest());
+    }
+
+    public function test_middleware_can_inspect_and_replace_response(): void
+    {
+        $handler = $this->handler([new PsrResponse(200, [], 'body')]);
+        $handler->addMiddleware(function (RequestInterface $request, callable $next) {
+            $response = $next($request);
+
+            return $response->withHeader('X-Wrapped', 'yes');
+        });
+
+        $response = $handler->get('https://example.com/x');
+
+        $this->assertSame('yes', $response->getHeaderLine('X-Wrapped'));
+    }
+
+    public function test_priority_controls_execution_order_end_to_end(): void
+    {
+        $handler = $this->handler([new PsrResponse(200)]);
+        $order = [];
+
+        $handler->addMiddleware(function (RequestInterface $r, callable $n) use (&$order) {
+            $order[] = 'low';
+
+            return $n($r);
+        }, 1);
+
+        $handler->addMiddleware(function (RequestInterface $r, callable $n) use (&$order) {
+            $order[] = 'high';
+
+            return $n($r);
+        }, 10);
+
+        $handler->get('https://example.com/x');
+
+        $this->assertSame(['high', 'low'], $order);
+    }
+
+    public function test_middleware_can_rewrite_request_body(): void
+    {
+        $handler = $this->handler([new PsrResponse(200)]);
+        $handler->addMiddleware(
+            fn (RequestInterface $request, callable $next) => $next($request->withBody(Utils::streamFor('rewritten')))
+        );
+
+        $handler->post('https://example.com/x', ['original' => true]);
+
+        $this->assertSame('rewritten', (string) $this->mock->getLastRequest()->getBody());
+    }
+
+    public function test_middleware_applies_in_async_mode(): void
+    {
+        $handler = $this->handler([new PsrResponse(200, [], 'ok')]);
+        $handler->addMiddleware(new AddHeadersMiddleware(['X-Async' => 'yes']));
+
+        $result = $handler->async()->get('https://example.com/x');
+
+        $this->assertInstanceOf(PromiseInterface::class, $result);
+
+        $response = await($result);
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame('yes', $this->mock->getLastRequest()->getHeaderLine('X-Async'));
+    }
+
+    public function test_when_conditionally_adds_middleware(): void
+    {
+        $handler = $this->handler([new PsrResponse(200), new PsrResponse(200)]);
+
+        $handler
+            ->when(true, fn (ClientHandler $h) => $h->addMiddleware(new AddHeadersMiddleware(['X-On' => '1'])))
+            ->unless(true, fn (ClientHandler $h) => $h->addMiddleware(new AddHeadersMiddleware(['X-Off' => '1'])));
+
+        $handler->get('https://example.com/x');
+
+        $this->assertSame('1', $this->mock->getLastRequest()->getHeaderLine('X-On'));
+        $this->assertFalse($this->mock->getLastRequest()->hasHeader('X-Off'));
+    }
+
+    public function test_without_middleware_removes_registered_middleware(): void
+    {
+        $handler = $this->handler([new PsrResponse(200)]);
+        $handler->addMiddleware(new AddHeadersMiddleware(['X-Gone' => '1']));
+        $handler->withoutMiddleware(AddHeadersMiddleware::class);
+
+        $handler->get('https://example.com/x');
+
+        $this->assertFalse($this->mock->getLastRequest()->hasHeader('X-Gone'));
+    }
+}

--- a/tests/Unit/ManagesMiddlewareTest.php
+++ b/tests/Unit/ManagesMiddlewareTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Fetch\Concerns\ManagesMiddleware;
+use Fetch\Middleware\AddHeadersMiddleware;
+use PHPUnit\Framework\TestCase;
+
+class ManagesMiddlewareTest extends TestCase
+{
+    private function handler(): object
+    {
+        return new class
+        {
+            use ManagesMiddleware;
+        };
+    }
+
+    public function test_starts_empty(): void
+    {
+        $handler = $this->handler();
+
+        $this->assertFalse($handler->hasMiddleware());
+        $this->assertSame([], $handler->getMiddleware());
+    }
+
+    public function test_add_middleware_is_fluent_and_tracked(): void
+    {
+        $handler = $this->handler();
+        $mw = fn ($request, $next) => $next($request);
+
+        $this->assertSame($handler, $handler->addMiddleware($mw));
+        $this->assertTrue($handler->hasMiddleware());
+        $this->assertSame([$mw], $handler->getMiddleware());
+    }
+
+    public function test_priority_orders_highest_first(): void
+    {
+        $handler = $this->handler();
+        $low = fn ($r, $n) => $n($r);
+        $high = fn ($r, $n) => $n($r);
+        $mid = fn ($r, $n) => $n($r);
+
+        $handler->addMiddleware($low, 1);
+        $handler->addMiddleware($high, 10);
+        $handler->addMiddleware($mid, 5);
+
+        $this->assertSame([$high, $mid, $low], $handler->getMiddleware());
+    }
+
+    public function test_equal_priority_keeps_insertion_order(): void
+    {
+        $handler = $this->handler();
+        $first = fn ($r, $n) => $n($r);
+        $second = fn ($r, $n) => $n($r);
+        $third = fn ($r, $n) => $n($r);
+
+        $handler->addMiddleware($first);
+        $handler->addMiddleware($second);
+        $handler->addMiddleware($third);
+
+        $this->assertSame([$first, $second, $third], $handler->getMiddleware());
+    }
+
+    public function test_middleware_replaces_stack_and_accepts_priority_pairs(): void
+    {
+        $handler = $this->handler();
+        $a = fn ($r, $n) => $n($r);
+        $b = fn ($r, $n) => $n($r);
+
+        $handler->addMiddleware(fn ($r, $n) => $n($r));
+        $handler->middleware([[$a, 1], [$b, 100]]);
+
+        $this->assertSame([$b, $a], $handler->getMiddleware());
+    }
+
+    public function test_without_middleware_clears_all(): void
+    {
+        $handler = $this->handler();
+        $handler->addMiddleware(fn ($r, $n) => $n($r));
+
+        $handler->withoutMiddleware();
+
+        $this->assertFalse($handler->hasMiddleware());
+    }
+
+    public function test_without_middleware_removes_by_class(): void
+    {
+        $handler = $this->handler();
+        $callable = fn ($r, $n) => $n($r);
+        $handler->addMiddleware(new AddHeadersMiddleware(['X-A' => '1']));
+        $handler->addMiddleware($callable);
+
+        $handler->withoutMiddleware(AddHeadersMiddleware::class);
+
+        $this->assertSame([$callable], $handler->getMiddleware());
+    }
+
+    public function test_when_applies_callback_on_truthy_condition(): void
+    {
+        $handler = $this->handler();
+
+        $handler->when(true, fn ($h) => $h->addMiddleware(fn ($r, $n) => $n($r)));
+        $handler->when(false, fn ($h) => $h->addMiddleware(fn ($r, $n) => $n($r)));
+
+        $this->assertCount(1, $handler->getMiddleware());
+    }
+
+    public function test_when_passes_resolved_value_and_supports_default(): void
+    {
+        $handler = $this->handler();
+        $seen = null;
+
+        $handler->when(
+            fn ($h) => 'resolved',
+            function ($h, $value) use (&$seen) {
+                $seen = $value;
+            },
+        );
+
+        $this->assertSame('resolved', $seen);
+
+        $defaultCalled = false;
+        $handler->when(false, fn () => null, function () use (&$defaultCalled) {
+            $defaultCalled = true;
+        });
+
+        $this->assertTrue($defaultCalled);
+    }
+
+    public function test_unless_applies_callback_on_falsy_condition(): void
+    {
+        $handler = $this->handler();
+
+        $handler->unless(false, fn ($h) => $h->addMiddleware(fn ($r, $n) => $n($r)));
+        $handler->unless(true, fn ($h) => $h->addMiddleware(fn ($r, $n) => $n($r)));
+
+        $this->assertCount(1, $handler->getMiddleware());
+    }
+}

--- a/tests/Unit/Middleware/AddHeadersMiddlewareTest.php
+++ b/tests/Unit/Middleware/AddHeadersMiddlewareTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Middleware;
+
+use Fetch\Middleware\AddHeadersMiddleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class AddHeadersMiddlewareTest extends TestCase
+{
+    public function test_adds_headers(): void
+    {
+        $middleware = new AddHeadersMiddleware(['X-Api-Version' => '2.1', 'X-Tenant' => 'acme']);
+        $request = new Request('GET', 'https://example.com');
+
+        $middleware->handle($request, function (RequestInterface $req) {
+            $this->assertSame('2.1', $req->getHeaderLine('X-Api-Version'));
+            $this->assertSame('acme', $req->getHeaderLine('X-Tenant'));
+
+            return new Response(200);
+        });
+    }
+
+    public function test_overwrites_existing_headers_by_default(): void
+    {
+        $middleware = new AddHeadersMiddleware(['X-Api-Version' => 'new']);
+        $request = (new Request('GET', 'https://example.com'))->withHeader('X-Api-Version', 'old');
+
+        $middleware->handle($request, function (RequestInterface $req) {
+            $this->assertSame('new', $req->getHeaderLine('X-Api-Version'));
+
+            return new Response(200);
+        });
+    }
+
+    public function test_preserves_existing_headers_when_overwrite_disabled(): void
+    {
+        $middleware = new AddHeadersMiddleware(['X-Api-Version' => 'new'], overwrite: false);
+        $request = (new Request('GET', 'https://example.com'))->withHeader('X-Api-Version', 'old');
+
+        $middleware->handle($request, function (RequestInterface $req) {
+            $this->assertSame('old', $req->getHeaderLine('X-Api-Version'));
+
+            return new Response(200);
+        });
+    }
+}

--- a/tests/Unit/Middleware/LoggingMiddlewareTest.php
+++ b/tests/Unit/Middleware/LoggingMiddlewareTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Middleware;
+
+use Fetch\Middleware\LoggingMiddleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+
+class LoggingMiddlewareTest extends TestCase
+{
+    private function collectingLogger(array &$logs): AbstractLogger
+    {
+        return new class($logs) extends AbstractLogger
+        {
+            public function __construct(private array &$logs) {}
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->logs[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+    }
+
+    public function test_logs_request_and_response_with_correlation_id(): void
+    {
+        $logs = [];
+        $middleware = new LoggingMiddleware($this->collectingLogger($logs));
+        $request = new Request('GET', 'https://example.com/api');
+
+        $middleware->handle($request, fn (RequestInterface $req) => new Response(200));
+
+        $this->assertCount(2, $logs);
+        $this->assertSame('HTTP request started', $logs[0]['message']);
+        $this->assertSame('HTTP request completed', $logs[1]['message']);
+        $this->assertSame(200, $logs[1]['context']['status_code']);
+
+        // Same correlation id links both entries.
+        $this->assertNotEmpty($logs[0]['context']['correlation_id']);
+        $this->assertSame($logs[0]['context']['correlation_id'], $logs[1]['context']['correlation_id']);
+    }
+
+    public function test_attaches_correlation_header_to_request(): void
+    {
+        $logs = [];
+        $middleware = new LoggingMiddleware($this->collectingLogger($logs));
+        $request = new Request('GET', 'https://example.com');
+
+        $middleware->handle($request, function (RequestInterface $req) {
+            $this->assertNotEmpty($req->getHeaderLine('X-Correlation-ID'));
+
+            return new Response(200);
+        });
+    }
+
+    public function test_respects_custom_level(): void
+    {
+        $logs = [];
+        $middleware = new LoggingMiddleware($this->collectingLogger($logs), LogLevel::DEBUG);
+
+        $middleware->handle(new Request('GET', 'https://example.com'), fn () => new Response(200));
+
+        $this->assertSame(LogLevel::DEBUG, $logs[0]['level']);
+    }
+}

--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Fetch\Http\MiddlewarePipeline;
+use Fetch\Interfaces\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class MiddlewarePipelineTest extends TestCase
+{
+    private function request(): RequestInterface
+    {
+        return new Request('GET', 'https://example.com');
+    }
+
+    public function test_empty_pipeline_calls_core_directly(): void
+    {
+        $pipeline = new MiddlewarePipeline([]);
+
+        $response = $pipeline->handle($this->request(), fn () => new Response(200));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function test_middleware_execute_in_onion_order(): void
+    {
+        $order = [];
+
+        $make = function (string $tag) use (&$order) {
+            return function (RequestInterface $request, callable $next) use (&$order, $tag): ResponseInterface {
+                $order[] = "before:$tag";
+                $response = $next($request);
+                $order[] = "after:$tag";
+
+                return $response;
+            };
+        };
+
+        $pipeline = new MiddlewarePipeline([$make('a'), $make('b')]);
+
+        $pipeline->handle($this->request(), function () use (&$order) {
+            $order[] = 'core';
+
+            return new Response(200);
+        });
+
+        $this->assertSame(
+            ['before:a', 'before:b', 'core', 'after:b', 'after:a'],
+            $order,
+        );
+    }
+
+    public function test_middleware_can_modify_request(): void
+    {
+        $add = fn (RequestInterface $request, callable $next) => $next($request->withHeader('X-Test', 'yes'));
+
+        $pipeline = new MiddlewarePipeline([$add]);
+
+        $pipeline->handle($this->request(), function (RequestInterface $request) {
+            $this->assertSame('yes', $request->getHeaderLine('X-Test'));
+
+            return new Response(200);
+        });
+    }
+
+    public function test_middleware_can_short_circuit(): void
+    {
+        $coreCalled = false;
+
+        $shortCircuit = fn (RequestInterface $request, callable $next) => new Response(418, [], 'teapot');
+
+        $pipeline = new MiddlewarePipeline([$shortCircuit]);
+
+        $response = $pipeline->handle($this->request(), function () use (&$coreCalled) {
+            $coreCalled = true;
+
+            return new Response(200);
+        });
+
+        $this->assertFalse($coreCalled);
+        $this->assertSame(418, $response->getStatusCode());
+    }
+
+    public function test_supports_middleware_objects(): void
+    {
+        $middleware = new class implements Middleware
+        {
+            public function handle(RequestInterface $request, callable $next): ResponseInterface
+            {
+                return $next($request->withHeader('X-Object', 'ok'));
+            }
+        };
+
+        $pipeline = new MiddlewarePipeline([$middleware]);
+
+        $pipeline->handle($this->request(), function (RequestInterface $request) {
+            $this->assertSame('ok', $request->getHeaderLine('X-Object'));
+
+            return new Response(200);
+        });
+    }
+
+    public function test_rejects_callable_returning_invalid_type(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $bad = fn (RequestInterface $request, callable $next) => 'not a response';
+
+        (new MiddlewarePipeline([$bad]))->handle($this->request(), fn () => new Response(200));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the **Middleware/Interceptor System** requested in #39 — a PSR-7-based middleware pipeline for wrapping the request/response lifecycle with cross-cutting concerns (auth, logging, versioning, tenancy, caching layers, circuit breakers, …) without touching every call site.

Closes #39.

## What's new

- **`Fetch\Interfaces\Middleware`** — `handle(RequestInterface $request, callable $next): ResponseInterface|PromiseInterface`. Plain callables with the same signature are accepted anywhere a middleware is, so trivial middleware need no class.
- **`Fetch\Http\MiddlewarePipeline`** — composes an ordered, outermost-first stack into a single onion around the core request handler. Transport-agnostic: passes through sync responses and async promises unchanged.
- **`Fetch\Concerns\ManagesMiddleware`** — `addMiddleware()`, `middleware()`, `withoutMiddleware()`, `getMiddleware()`, plus `when()` / `unless()` conditionals, on both `ClientHandler` and `Client`. **Priority ordering** (highest runs first, stable on ties).
- **Integration** in `PerformsHttpRequests::sendRequest()`: builds a PSR-7 request from the resolved method/URI/headers/body, runs it through the pipeline, and folds middleware changes back into the Guzzle options before the built-in mock/cache/retry/execute core. Middleware therefore sit **outside** caching and can **short-circuit** (any PSR-7 response returned is coerced into a buffered `Response`). Works in **async mode** too.
- **Built-in middleware**: `AddHeadersMiddleware` (inject/override headers) and `LoggingMiddleware` (PSR-3 request/response logging with a correlation id; sync + async).

## Design notes

- Purely additive — no breaking changes. Targets a **v3.7.0** minor release.
- Middleware operate on the PSR-7 request's method, URI, headers, and body; body rewrites are sent verbatim while structured `json`/`form_params`/`multipart` bodies are preserved when untouched.
- Docs: README feature, `CODE_MAP.md` section, new `docs/guide/middleware.md` (+ sidebar), `CHANGELOG.md` `v3.7.0`.

## Testing

- 30 new tests: pipeline ordering/short-circuit/callables (`MiddlewarePipelineTest`), stack management + priority + `when`/`unless` (`ManagesMiddlewareTest`), built-ins, and end-to-end integration via a Guzzle mock handler covering header injection, short-circuit, response mutation, priority, body rewrite, async, and conditional/removal (`MiddlewareTest`).
- Full suite: **548 tests pass**. PHPStan clean. Duster lint clean. VitePress docs build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)