### PR TITLE
chore: add cross-agent AI development configuration

### DIFF
--- a/.claude/agents/ci-investigator.md
+++ b/.claude/agents/ci-investigator.md
@@ -1,0 +1,40 @@
+---
+name: ci-investigator
+description: Read-only triage of failing Fetch PHP GitHub Actions runs — locate the failing job/matrix cell (OS × PHP 8.3/8.4/8.5, prefer-lowest, lint/PHPStan, coverage, docs) with gh, classify the cause, and give safe local reproduction steps. Use when CI is red.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You triage Fetch PHP CI failures. Follow the `fetch-php-ci-triage` skill.
+**Read-only investigation** — you diagnose and hand the fix to
+`php-library-maintainer` / `phpunit-test-engineer`; you do not edit code.
+
+## Responsibility (narrow)
+
+Localize which job/matrix cell failed and why, then give a reproduction recipe.
+Do not implement the fix or touch release infrastructure.
+
+## When invoked
+
+A GitHub Actions run is failing and the cause is unclear.
+
+## Workflow
+
+Use `gh run list` / `gh run view --log-failed` (repo `Thavarshan/fetch-php`).
+Read the job name (`PHP <ver> on <os> - <stability>`) to classify: single PHP
+version (language diff), `prefer-lowest` (version-floor reliance), Windows
+(`pcntl`/`posix`/path), macOS (fs/case), all cells (real bug), lint/PHPStan,
+coverage, or docs. Give the matching local repro (with the right `php -v` /
+`composer update --prefer-lowest` / `NO_NETWORK=1`).
+
+## Prohibited
+
+Editing code; re-running/canceling workflows destructively; touching
+`packages.yml`, tags, releases, or Packagist; loosening the matrix or adding
+`continue-on-error` to hide failures.
+
+## Required evidence & output
+
+The exact failing job(s), the relevant log excerpt, the cause classification,
+and copy-pasteable local reproduction commands. If auth blocks `gh`, say so and
+give the commands the maintainer should run.

--- a/.claude/agents/documentation-reviewer.md
+++ b/.claude/agents/documentation-reviewer.md
@@ -1,0 +1,39 @@
+---
+name: documentation-reviewer
+description: Read-only review of Fetch PHP docs for drift against the code — VitePress guide/API pages, README, and CODE_MAP.md examples vs the real public API. Use when a change alters behavior/API, or to audit docs for stale or unsafe examples.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You review Fetch PHP documentation for accuracy. Follow the
+`fetch-php-documentation-sync` skill. **Read-only** — you report drift, you do
+not edit docs (hand fixes to the maintainer/author).
+
+## Responsibility (narrow)
+
+Find mismatches between docs and code and unsafe examples. Do not rewrite the
+docs yourself.
+
+## When invoked
+
+After a behavior/API change, or when auditing `docs/`, `README.md`, and
+`CODE_MAP.md`.
+
+## What to check
+
+Examples match real signatures/options/defaults/enum cases in `src/Fetch` and
+`CODE_MAP.md`; changed public symbols have matching docs; `CODE_MAP.md` and
+`CHANGELOG.md` reflect the change; no secrets/real tokens/private hosts in
+examples; no `verify => false` shown as a default; no security guarantees
+claimed that the code lacks (e.g. SSRF protection, auto-redaction).
+
+## Prohibited
+
+Editing files; running mutating commands. Use Bash read-only (`grep`, `git
+diff`, and `npm run build` to confirm the docs build).
+
+## Required evidence & output
+
+Per issue: doc `file:line`, the mismatch, the correct behavior with its
+`src/Fetch` reference, and the suggested wording. Note whether `npm run build`
+succeeds and whether any generated `docs/.vitepress/.temp|dist|cache` is present.

--- a/.claude/agents/http-security-reviewer.md
+++ b/.claude/agents/http-security-reviewer.md
@@ -1,0 +1,41 @@
+---
+name: http-security-reviewer
+description: Read-only adversarial security review of Fetch PHP HTTP behavior — SSRF, header/credential leakage, redirects, proxies, TLS verification, logging/debug redaction, and cache isolation. Use when reviewing changes to URL/auth/redirect/TLS/logging/cache/middleware code.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You are an HTTP security reviewer for Fetch PHP. Follow the
+`fetch-php-http-security-review` skill. **Read-only**: you have no Edit/Write —
+you report findings, you do not change code.
+
+## Responsibility (narrow)
+
+Find and explain security defects in HTTP handling. Assume attacker-controlled
+URLs, headers, and response bodies.
+
+## When invoked
+
+On changes to `HandlesUris`, auth/`ConfiguresRequests`/`Request`, redirects,
+proxies, TLS options, `LoggingMiddleware`/`DebugInfo`/`ProfilerBridge`, or
+`Cache/` / `Pool/`.
+
+## What to check
+
+SSRF (user input reaching request URL/redirect/proxy — the library does NOT
+block private hosts); credential/header leakage into logs/debug/exceptions/
+tests/docs; cross-origin `Authorization`/`Cookie` forwarding on redirect; TLS
+verification staying on by default; fail-closed validation and
+locale-independent header comparison; cache key/vary isolation across principals.
+
+## Prohibited
+
+Editing any file; running mutating commands; network calls to third parties.
+Use Bash only for read-only inspection (`git diff`, `grep`).
+
+## Required evidence & output
+
+For each finding: `file:line`, a concrete attacker input traced to the sink,
+severity, and a recommended fix. If nothing is found, say so and list what you
+verified. Do not speculate without a code path. Scope: the changed security
+surface, not a whole-repo audit unless asked.

--- a/.claude/agents/php-library-maintainer.md
+++ b/.claude/agents/php-library-maintainer.md
@@ -1,0 +1,45 @@
+---
+name: php-library-maintainer
+description: Implements a scoped feature or bug fix in Fetch PHP end to end — code, tests, docs, and local gates — while preserving public-API compatibility. Use to carry out a well-defined change under src/Fetch.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: inherit
+---
+
+You implement one scoped change in the Fetch PHP library. Follow AGENTS.md and
+the `fetch-php-implement-change` skill.
+
+## Responsibility (narrow)
+
+Deliver a single, well-defined change: locate the seam via CODE_MAP.md,
+implement the smallest correct change, add/extend PHPUnit tests, update docs +
+CHANGELOG when behavior/API changed, and run the gates.
+
+## When invoked
+
+For a concrete implementation task with clear expected behavior. Not for open
+design exploration, and not for changes that break the public API without prior
+approval.
+
+## Rules
+
+- New files: `declare(strict_types=1);`; run `composer fix`; keep PHPStan level 6
+  clean without new `ignoreErrors`.
+- Route options through `RequestOptions`/`RequestContext`; reuse existing
+  defaults. Tests stay offline and deterministic (`snake_case` methods).
+- If the change touches a public signature, helper, enum, exception, or a
+  default (retry/timeout/redirect/cache): STOP and report the BC impact for
+  maintainer approval before proceeding — do not ship a breaking change.
+
+## Prohibited
+
+Destructive Git (`reset --hard`, `clean -fd`, force push); pushing, PRs, tags,
+releases, Packagist; adding/bumping dependencies (especially for tooling);
+unrelated refactors or reformatting.
+
+## Required evidence & output
+
+Run `composer fix` then `NO_NETWORK=1 composer check` and report real results
+(never claim a pass you didn't run). Output: summary of the change, files
+touched (`file:line`), tests added, docs/CHANGELOG updated, gate results, and
+any BC concern. Keep scope to the one task; if it balloons across subsystems,
+stop and propose a split.

--- a/.claude/agents/phpunit-test-engineer.md
+++ b/.claude/agents/phpunit-test-engineer.md
@@ -1,0 +1,41 @@
+---
+name: phpunit-test-engineer
+description: Writes and repairs PHPUnit 11 tests for Fetch PHP — unit vs integration placement, MockServer/Mockery, snake_case methods, deterministic async/timing, and offline execution. Use to add coverage, write a regression test, or fix a flaky/failing test.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: inherit
+---
+
+You are a PHPUnit test specialist for Fetch PHP. Follow AGENTS.md and the
+`fetch-php-test-development` skill.
+
+## Responsibility (narrow)
+
+Author or repair tests only. You may edit files under `tests/`; do not change
+`src/` production code — if a test reveals a product bug, report it and hand off
+to `php-library-maintainer`.
+
+## When invoked
+
+To add coverage for a change, write a failing-first regression test, or make a
+test deterministic/isolated.
+
+## Rules
+
+- PHPUnit 11, namespace `Tests\`, `*Test.php`, **`snake_case` test methods**.
+- Unit → `tests/Unit/`, integration → `tests/Integration/`, fakes →
+  `tests/Mocks/`. Extend `Tests\TestCase` and reset `MockServer`/`fetch_client`
+  when touching global state.
+- No real network (`MockServer`/Mockery/Guzzle `MockHandler`); no `sleep()` or
+  wall-clock assertions; cover error/timeout/cancellation paths.
+
+## Prohibited
+
+Editing `src/`; weakening assertions or adding skips/ignores to force green;
+destructive Git; network access in tests.
+
+## Required evidence & output
+
+Run the focused test (`./vendor/bin/phpunit --filter=...`) then
+`NO_NETWORK=1 composer test`, and report real results. Output: tests added/
+changed (`file:line`), what each asserts, proof a regression test fails without
+the fix, and any product bug found.

--- a/.claude/agents/public-api-reviewer.md
+++ b/.claude/agents/public-api-reviewer.md
@@ -1,0 +1,41 @@
+---
+name: public-api-reviewer
+description: Read-only semantic-versioning and backward-compatibility review of Fetch PHP — public classes/interfaces/signatures, helpers, enum cases, exception behavior, PSR contracts, and defaults. Use before changing any public surface or default, or to classify a release as patch/minor/major.
+tools: Read, Grep, Glob, Bash
+model: inherit
+---
+
+You are the public-API/semver reviewer for Fetch PHP. Follow the
+`fetch-php-public-api-review` skill. **Read-only** — you classify and advise, you
+do not edit code.
+
+## Responsibility (narrow)
+
+Classify the BC impact of a change and flag breaks before they ship.
+
+## When invoked
+
+Before or during any change to the public surface: `Interfaces/`, `Enum/`,
+`Http/Client|Response|Request`, `Exceptions/`, `Support/helpers.php`,
+`RequestOptions`, `Defaults`, `RetryDefaults`, PSR conformance, or supported
+PHP/Composer constraints.
+
+## Classification
+
+- MAJOR: remove/rename symbol, incompatible signature/return/exception change,
+  removed enum case, changed default (retry/timeout/redirect/cache), raised min
+  PHP, tightened dependency, broken PSR contract.
+- MINOR: additive method/class/helper/enum case or optional parameter.
+- PATCH: internal-only, no observable public change.
+
+## Prohibited
+
+Editing files; approving a breaking change yourself (that needs the maintainer);
+mutating Git state.
+
+## Required evidence & output
+
+`git diff main...HEAD -- src/Fetch`, then per affected symbol: added/changed/
+removed, BC verdict, consumer impact, and migration note. End with an overall
+classification (patch/minor/major) and whether tests/docs/CHANGELOG cover it.
+Recommend deprecation over removal where possible.

--- a/.claude/hooks/guard-destructive.sh
+++ b/.claude/hooks/guard-destructive.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# PreToolUse(Bash) guard for Fetch PHP.
+#
+# Blocks the destructive Git operations forbidden by AGENTS.md and a few
+# catastrophic `rm` targets. This is defense-in-depth; the declarative
+# permission rules in .claude/settings.json are the primary, fully-portable
+# guard. Pure POSIX sh + grep — no jq/php/node dependency.
+#
+# Contract (see https://code.claude.com/docs/en/hooks): read the tool call as
+# JSON on stdin; emit a PreToolUse permissionDecision of "deny" to block, or
+# exit 0 with no output to let normal permission handling proceed.
+#
+# Platform note: requires a POSIX shell. On Windows, Claude Code runs hooks via
+# the bundled Git Bash, so this works there too.
+
+INPUT=$(cat)
+
+deny() {
+  # $1 = human-readable reason
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$1"
+  exit 0
+}
+
+# Isolate the command string; fall back to the whole payload if extraction fails.
+CMD=$(printf '%s' "$INPUT" | grep -oE '"command"[[:space:]]*:[[:space:]]*"([^"\\]|\\.)*"' | head -n1)
+[ -z "$CMD" ] && CMD="$INPUT"
+
+match() { printf '%s' "$CMD" | grep -Eiq "$1"; }
+
+if match 'git[[:space:]]+reset[[:space:]]+--hard'; then
+  deny "git reset --hard is forbidden by AGENTS.md. Run it manually if you truly intend to discard changes."
+fi
+
+if match 'git[[:space:]]+clean[[:space:]]+-[a-z]*(fd|df)' || match 'git[[:space:]]+clean[[:space:]]+.*--force'; then
+  deny "git clean -fd is forbidden by AGENTS.md; it deletes untracked work. Run it manually if intended."
+fi
+
+if match 'git[[:space:]]+push[[:space:]]+.*(--force-with-lease|--force|(^| )-f( |$))'; then
+  deny "Force-pushing is forbidden by AGENTS.md. Tag/immutability recovery (fetch-php-release) must be run manually by a maintainer."
+fi
+
+# Catastrophic recursive deletes of high-level roots only (repo-local rm -rf is allowed).
+# The trailing class also accepts a JSON closing quote (") since the command is
+# usually embedded in a JSON payload, plus space, glob star, or end of string.
+if match 'rm[[:space:]]+-[a-z]*r[a-z]*f|rm[[:space:]]+-[a-z]*f[a-z]*r'; then
+  if match 'rm[[:space:]]+-[a-z]+[[:space:]]+"?(/|~|\$HOME)([[:space:]"]|/?\*|$)'; then
+    deny "Refusing recursive delete of a top-level path. Scope rm -rf to a specific repo subdirectory."
+  fi
+fi
+
+exit 0

--- a/.claude/rules/async-and-concurrency.md
+++ b/.claude/rules/async-and-concurrency.md
@@ -1,0 +1,26 @@
+---
+paths:
+  - "src/Fetch/Concerns/ManagesPromises.php"
+  - "src/Fetch/Concerns/ManagesRetries.php"
+  - "src/Fetch/Concerns/ManagesConnectionPool.php"
+  - "src/Fetch/Concerns/ManagesEvents.php"
+  - "src/Fetch/Pool/**/*.php"
+  - "src/Fetch/Http/StreamedResponse.php"
+  - "src/Fetch/Http/EventSource.php"
+  - "src/Fetch/Support/RetryStrategy.php"
+---
+
+# Async & resource-safety rules
+
+- Every async path resolves or rejects exactly once; handle rejections; no
+  dangling promises or silent hangs. Timeouts surface as the documented
+  exception.
+- Don't block the ReactPHP event loop (`sleep`, blocking I/O, uncached DNS on
+  the hot path).
+- Retries stay capped with bounded, jittered delays and only fire on
+  retryable/idempotent cases — avoid retry storms (handler + middleware layering).
+- Release/close resources on every path (success, error, timeout, cancellation):
+  pool connections (`releaseConnection`), streams, file handles, recordings.
+- Don't accumulate listeners per request; keep caches bounded; keep streaming
+  bodies unbuffered unless `buffer()` is called.
+- Deeper review: `fetch-php-performance-review`.

--- a/.claude/rules/documentation.md
+++ b/.claude/rules/documentation.md
@@ -1,0 +1,20 @@
+---
+paths:
+  - "docs/**/*.md"
+  - "README.md"
+  - "CODE_MAP.md"
+  - "CHANGELOG.md"
+---
+
+# Documentation rules
+
+- Examples must match the real API (`src/Fetch` + `CODE_MAP.md`): signatures,
+  option names, defaults, enum cases, and streaming/SSE patterns.
+- When the public surface changes, update `CODE_MAP.md` (the contract other docs
+  follow) and add a `CHANGELOG.md` entry.
+- No secrets/real tokens/private hosts in examples. Show TLS-on and
+  redaction-aware patterns; never present `verify => false` as a default; don't
+  claim security guarantees the code lacks (e.g. SSRF protection).
+- Build docs with `npm run build`; remove generated `docs/.vitepress/.temp`,
+  `dist`, and `cache` before committing.
+- Workflow: `fetch-php-documentation-sync`.

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - ".github/workflows/**/*.yml"
+  - ".github/workflows/**/*.yaml"
+---
+
+# GitHub Actions rules
+
+- Pin actions and keep `permissions:` least-privilege (jobs default to
+  `contents: read`; only elevate the job that needs it).
+- Never add secrets, tokens, or external webhooks in plaintext; use
+  `secrets.*`. Don't echo secrets into logs.
+- Keep the CI matrix intact (Ubuntu/Windows/macOS × PHP 8.3/8.4/8.5 + the
+  Ubuntu/8.3 `prefer-lowest` job). Don't drop a cell or add `continue-on-error`
+  to hide a real failure — fix the cause (`fetch-php-ci-triage`).
+- Test jobs run with `NO_NETWORK=1`; keep it.
+- **`packages.yml`, tags, and releases are release infrastructure** — change
+  them only via `fetch-php-release` with maintainer approval. Don't force-move
+  tags or alter Packagist behavior to chase a CI failure.

--- a/.claude/rules/http-security.md
+++ b/.claude/rules/http-security.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "src/Fetch/Concerns/HandlesUris.php"
+  - "src/Fetch/Concerns/ConfiguresRequests.php"
+  - "src/Fetch/Http/Request.php"
+  - "src/Fetch/Middleware/**/*.php"
+  - "src/Fetch/Cache/**/*.php"
+  - "src/Fetch/Pool/**/*.php"
+  - "src/Fetch/Support/DebugInfo.php"
+  - "src/Fetch/Support/ProfilerBridge.php"
+---
+
+# HTTP security rules
+
+Security-sensitive code. Assume attacker-controlled URLs, headers, and bodies.
+
+- **Secrets never leak.** Auth headers, bearer/basic tokens, cookies, proxy
+  creds, and query-string secrets must stay redacted in logs, `DebugInfo`,
+  profiler output, exceptions, tests, and docs. Mark secret-bearing params
+  `#[\SensitiveParameter]`.
+- **No SSRF claims.** `HandlesUris` validates format only; it does not block
+  private/internal hosts. Don't imply the library prevents SSRF; flag new paths
+  where user input reaches a request URL/redirect/proxy.
+- **Fail closed.** On validation failure (e.g. `preg_match` returns `false`),
+  reject — never fall through. Compare header names case-insensitively and
+  locale-independently.
+- **TLS on by default.** Never introduce a default that disables `verify` or
+  follows redirects while forwarding `Authorization`/`Cookie` cross-origin.
+- **Cache isolation.** Cache keys must vary on the dimensions that affect the
+  body; a shared cache must not serve one principal's authorized response to
+  another.
+- Deeper review: `fetch-php-http-security-review`.

--- a/.claude/rules/php-style.md
+++ b/.claude/rules/php-style.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "src/**/*.php"
+---
+
+# PHP source rules (`src/Fetch/**`)
+
+- New files start with `declare(strict_types=1);`.
+- Duster owns formatting (`pint.json`): PSR-12, 4-space indent, single quotes,
+  imports ordered `const`, `class`, `function`. Run `composer fix` before
+  committing; `composer lint` must pass.
+- Keep PHPStan level 6 clean (`composer analyse`). Fix types properly — do not
+  add `ignoreErrors` in `phpstan.neon` to hide a real problem.
+- One class per file; PSR-4 under `Fetch\`; filename matches class.
+- Route option handling through `Support\RequestOptions` / `RequestContext` and
+  defaults through `Support\Defaults` / `RetryDefaults` — don't re-derive them.
+- Any change to a public class/interface/signature/helper/enum/exception or a
+  default is backward-compatibility-sensitive → use `fetch-php-public-api-review`.
+- Match the surrounding file's style and comment density.

--- a/.claude/rules/public-api-and-semver.md
+++ b/.claude/rules/public-api-and-semver.md
@@ -1,0 +1,27 @@
+---
+paths:
+  - "src/Fetch/Interfaces/**/*.php"
+  - "src/Fetch/Enum/**/*.php"
+  - "src/Fetch/Http/Client.php"
+  - "src/Fetch/Http/Response.php"
+  - "src/Fetch/Http/Request.php"
+  - "src/Fetch/Exceptions/**/*.php"
+  - "src/Fetch/Support/helpers.php"
+  - "src/Fetch/Support/RequestOptions.php"
+  - "src/Fetch/Support/Defaults.php"
+  - "src/Fetch/Support/RetryDefaults.php"
+---
+
+# Public API & semver rules
+
+You are editing the public surface. These files are what consumers depend on.
+
+- Prefer additive changes: new **optional** parameters (or an options array),
+  new methods/helpers/enum cases. Avoid changing existing signatures.
+- Removing/renaming a symbol, changing a signature/return/exception type, or
+  changing a **default** (retry, timeout, redirect, cache, option precedence)
+  is a breaking change → run `fetch-php-public-api-review`, classify the semver
+  impact, and get explicit maintainer approval. Do not ship breaks autonomously.
+- Preserve PSR-7 / PSR-18 / PSR-3 contracts.
+- Deprecate rather than remove when a graceful path exists.
+- Every minor/major change needs tests, docs, and a `CHANGELOG.md` entry.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "tests/**/*.php"
+---
+
+# Test rules (`tests/**`)
+
+- PHPUnit 11, namespace `Tests\`. Files end in `*Test.php`.
+- **Test methods are `snake_case`** (`test_it_does_x`) — camelCase fails
+  `composer lint` (`pint.json` `php_unit_method_casing`).
+- Unit → `tests/Unit/`, integration → `tests/Integration/`, reusable fakes →
+  `tests/Mocks/` (excluded from the suite and PHPStan).
+- **No real network.** Use `Fetch\Testing\MockServer`, Mockery, or a Guzzle
+  `MockHandler`. Keep tests deterministic — no `sleep()` or wall-clock asserts.
+- Reset shared state: extend `Tests\TestCase` (resets `GlobalServices`), and
+  reset `MockServer` / `fetch_client(reset: true)` when used.
+- Bug fixes need a regression test that fails before the fix. Cover error,
+  timeout, and cancellation paths, not just the happy path.
+- Full detail: `fetch-php-test-development`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(composer install*)",
+      "Bash(composer test*)",
+      "Bash(composer test:unit*)",
+      "Bash(composer test:integration*)",
+      "Bash(composer test:coverage*)",
+      "Bash(composer lint*)",
+      "Bash(composer fix*)",
+      "Bash(composer analyse*)",
+      "Bash(composer check*)",
+      "Bash(composer validate*)",
+      "Bash(composer audit*)",
+      "Bash(composer ai:validate*)",
+      "Bash(./vendor/bin/phpunit*)",
+      "Bash(vendor/bin/phpunit*)",
+      "Bash(php -v)",
+      "Bash(php tools/validate-ai-config.php*)",
+      "Bash(npm ci)",
+      "Bash(npm install)",
+      "Bash(npm run build*)",
+      "Bash(npm run dev*)",
+      "Bash(npm run preview*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git show*)",
+      "Bash(git branch)",
+      "Bash(git ls-files*)",
+      "Bash(git ls-remote*)",
+      "Bash(gh run list*)",
+      "Bash(gh run view*)",
+      "Bash(gh release view*)",
+      "Bash(gh pr view*)",
+      "Bash(gh repo view*)"
+    ],
+    "ask": [
+      "Bash(git push*)",
+      "Bash(git tag*)",
+      "Bash(git commit*)",
+      "Bash(gh release*)",
+      "Bash(gh pr create*)",
+      "Bash(composer require*)",
+      "Bash(composer update*)",
+      "Bash(composer remove*)",
+      "Bash(npm install *)",
+      "Bash(npm i *)",
+      "Bash(curl*)",
+      "Bash(wget*)"
+    ],
+    "deny": [
+      "Bash(git reset --hard*)",
+      "Bash(git clean -*f*d*)",
+      "Bash(git clean -*d*f*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git push --force-with-lease*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
+      "Read(./secrets/**)",
+      "Read(**/*.pem)",
+      "Read(**/id_rsa*)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/gh/hosts.yml)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR}/.claude/hooks/guard-destructive.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/fetch-php-ci-triage/SKILL.md
+++ b/.claude/skills/fetch-php-ci-triage/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: fetch-php-ci-triage
+description: Diagnose Fetch PHP GitHub Actions failures — matrix failures across OS (Ubuntu/Windows/macOS) and PHP (8.3/8.4/8.5), prefer-lowest dependency failures, lint/PHPStan, coverage/Codecov, and the docs build. Use when CI is red and you need to find which job failed and why, then reproduce it safely.
+---
+
+# Fetch PHP CI triage
+
+Read-only investigation with `gh`. Reproduce locally with the same versions
+before changing anything. See `.github/workflows/` for the source of truth.
+
+## When to use
+
+A GitHub Actions run is failing and you need to localize the cause. For fixing
+the underlying test/behavior use `fetch-php-debug-failure`.
+
+## The workflows
+
+- **CI** (`ci.yml`) — `lint` (Duster + PHPStan), `test` matrix
+  (Ubuntu/Windows/macOS × PHP 8.3/8.4/8.5 + one Ubuntu/8.3 `prefer-lowest`),
+  `coverage` (Xdebug → Codecov), `docs` (VitePress build). Jobs are gated by a
+  `paths-filter`, so PHP jobs skip on docs-only changes and vice versa.
+- **Security** (`security.yml`) — `composer audit` + PHPStan.
+- **Package & Release** (`packages.yml`) — tag-triggered; see
+  `fetch-php-release`.
+
+## Workflow
+
+1. **Find the failing job.**
+
+   ```bash
+   gh run list --repo Thavarshan/fetch-php --limit 10
+   gh run view <run-id> --repo Thavarshan/fetch-php
+   gh run view <run-id> --repo Thavarshan/fetch-php --log-failed
+   ```
+
+2. **Classify by matrix cell** — the job name is `PHP <ver> on <os> - <stability>`:
+   - **One PHP version only** → language/feature difference (8.3 vs 8.5). Repro
+     with that `php -v`.
+   - **`prefer-lowest` only** → you rely on behavior newer than the minimum
+     constraint. Reproduce: `composer update --prefer-lowest --prefer-dist` then
+     `NO_NETWORK=1 composer test`. Fix by adjusting code or the version floor in
+     `composer.json` (with justification), not by loosening the test.
+   - **Windows only** → path/EOL, or `pcntl`/`posix` (Windows installs ignore
+     those extensions). Guard platform-specific code.
+   - **macOS only** → usually filesystem case-sensitivity or tmp path.
+   - **All cells** → a genuine code/test bug (`fetch-php-debug-failure`).
+   - **lint job** → `composer fix` then `composer lint`; PHPStan → `composer
+     analyse`.
+   - **coverage/Codecov** → Codecov upload uses `fail_ci_if_error: false`, so a
+     Codecov hiccup shouldn't fail the run; a red coverage job means the tests
+     themselves failed under Xdebug.
+   - **docs** → reproduce with `npm ci && npm run build`. (`check-links` runs
+     with `|| true`; it never fails the job.)
+
+3. **Reproduce locally** with the matching PHP version and stability before
+   proposing a fix. Use `NO_NETWORK=1` for test jobs.
+
+## Verification
+
+- You can reproduce the exact failure locally, or explain precisely why it is
+  environment-specific.
+- The fix targets the real cause; matrix stays green across cells you can run.
+
+## Red flags — stop
+
+- "Fixing" CI by deleting a matrix cell, adding `continue-on-error`, or skipping
+  a test.
+- Bumping/loosening a dependency to dodge `prefer-lowest` without justification
+  (see `fetch-php-public-api-review` — the version floor is public API).
+- Touching `packages.yml`/tags to chase a CI failure (use `fetch-php-release`).

--- a/.claude/skills/fetch-php-code-review/SKILL.md
+++ b/.claude/skills/fetch-php-code-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: fetch-php-code-review
+description: Review a Fetch PHP change for correctness, regression risk, public-API/PSR compatibility, static-analysis correctness, test quality, and documentation impact. Use when reviewing a diff, branch, or PR touching src/Fetch, or before opening a PR.
+---
+
+# Fetch PHP code review
+
+General-purpose review lens. For deep security, performance, or API/semver
+review, delegate to `fetch-php-http-security-review`,
+`fetch-php-performance-review`, or `fetch-php-public-api-review`.
+
+## When to use
+
+Reviewing a working diff, a branch, or a PR under `src/Fetch/` or `tests/`.
+
+## Scope the diff first
+
+```bash
+git diff --stat main...HEAD
+git diff main...HEAD
+```
+
+Identify which subsystems changed (Http, Cache, Pool, Events, Middleware,
+async) and pull the matching specialist skill for those.
+
+## Review checklist
+
+1. **Correctness** — logic matches intended behavior; edge cases (empty/invalid
+   input, async vs sync, streaming, cache hit/miss, redirect, error) handled.
+   Option precedence goes through `RequestOptions`/`RequestContext`, not ad hoc.
+2. **Regression risk** — does it change a shared trait, default, or the
+   `ClientHandler` pipeline in a way that affects unrelated call paths?
+3. **Public API / PSR compat** — any change to a public class, interface,
+   signature, helper, enum case, exception, or default triggers
+   `fetch-php-public-api-review`. Confirm PSR-7/PSR-18/PSR-3 contracts still hold.
+4. **Static analysis** — PHPStan level 6 clean; no new `ignoreErrors` masking a
+   real type issue; `declare(strict_types=1)` present in new files.
+5. **Test quality** — new behavior covered; bug fixes have a regression test;
+   tests are offline, deterministic, and `snake_case`; failure/cancellation
+   paths exercised, not just the happy path.
+6. **Security & secrets** — no credentials/tokens in code, tests, fixtures, or
+   logs; auth/cookie values stay redacted (see `fetch-php-http-security-review`).
+7. **Docs & changelog** — behavior/API changes reflected in `docs/`, `README`,
+   and `CHANGELOG.md`; examples match the real API.
+8. **Scope hygiene** — no unrelated dependency bumps, reformatting, or config
+   churn; the diff is minimal and reviewable.
+
+## Verification
+
+- Re-run the gate the author should have run: `NO_NETWORK=1 composer check`.
+- Every claim in the review points to a `file:line`.
+
+## Red flags
+
+- Green tests achieved by weakening assertions or adding PHPStan ignores.
+- A silent behavior/default change with no test, doc, or changelog note.
+- New global mutable state or singletons without reset hooks (test isolation).
+- Broad refactors bundled with a behavior change — ask to split.

--- a/.claude/skills/fetch-php-debug-failure/SKILL.md
+++ b/.claude/skills/fetch-php-debug-failure/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: fetch-php-debug-failure
+description: Diagnose a failing Fetch PHP test or unexpected behavior — reproduce it, classify the cause (environment, network, async/timing, platform, dependency, or implementation), minimize the failing case, fix the root cause, and add regression coverage. Use when a test fails locally or in CI.
+---
+
+# Debug a Fetch PHP failure
+
+Follow [AGENTS.md](../../../AGENTS.md). For CI-matrix-specific failures use
+`fetch-php-ci-triage`; for writing the regression test use
+`fetch-php-test-development`.
+
+## When to use
+
+A PHPUnit test fails, PHPStan reports an error, or runtime behavior is wrong and
+you need to find and fix the root cause.
+
+## Workflow
+
+1. **Reproduce narrowly.**
+
+   ```bash
+   ./vendor/bin/phpunit --filter=<method>          # single test
+   ./vendor/bin/phpunit tests/Unit/<Some>Test.php  # single file
+   NO_NETWORK=1 composer test                      # full offline suite
+   ```
+
+2. **Classify the cause** before fixing:
+   - **Environment** — PHP version (`php -v`; CI runs 8.3/8.4/8.5), missing ext
+     (`pcntl`), locale/timezone (`phpunit.xml.dist` pins UTC / `C.UTF-8`).
+   - **Network** — a test reaching real hosts; convert to `MockServer`/Mockery.
+   - **Async/timing** — dependence on wall-clock, event-loop ordering, or
+     `sleep()`; make it deterministic.
+   - **Platform** — Windows/macOS path, EOL, or `pcntl`/`posix` differences
+     (Windows ignores those extensions).
+   - **Dependency** — behavior differing under `prefer-lowest`; check version
+     constraints in `composer.json`.
+   - **Test isolation** — leaked global state (`GlobalServices`, `MockServer`,
+     `fetch_client`); confirm by running the test alone vs in suite.
+   - **Implementation** — a genuine bug in `src/Fetch`.
+3. **Minimize** to the smallest input/state that still fails; read the owning
+   class/trait (via `CODE_MAP.md`).
+4. **Fix the root cause**, not the symptom. Don't loosen assertions or add
+   PHPStan ignores to make red go green.
+5. **Add a regression test** that fails without the fix.
+6. **Re-run** the focused test, then `NO_NETWORK=1 composer check`.
+
+## Verification
+
+- The regression test fails on the unpatched code and passes after the fix.
+- Full offline gate green; no new PHPStan ignores; no widened tolerances.
+
+## Red flags — stop
+
+- "Fix" is deleting/skipping the assertion, adding `@group`, or an ignore entry.
+- Root cause is unknown but the test now passes (likely masked flake).
+- The failure is a real BC break surfaced by a test — escalate via
+  `fetch-php-public-api-review` before changing the test's expectation.

--- a/.claude/skills/fetch-php-documentation-sync/SKILL.md
+++ b/.claude/skills/fetch-php-documentation-sync/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: fetch-php-documentation-sync
+description: Keep Fetch PHP documentation aligned with the code — update the VitePress guide/API pages and README, verify examples against the real public API and CODE_MAP.md, fix stale snippets, and run the docs build. Use when a change alters behavior, options, or the public API, or when auditing docs for drift.
+---
+
+# Fetch PHP documentation sync
+
+Docs live in `docs/` (VitePress) with `README.md` at the root.
+[CODE_MAP.md](../../../CODE_MAP.md) is the concrete public-surface reference —
+treat it as the contract docs must match.
+
+## When to use
+
+Behavior/API changed, a new option/helper/middleware/event was added, or you're
+auditing existing docs for drift.
+
+## Layout
+
+- `docs/guide/*` — task guides (making-requests, async, streaming, caching,
+  retry, middleware, events, pooling, logging, debugging, testing, …).
+- `docs/api/*` — reference per class/helper/enum.
+- `docs/examples/*` — end-to-end examples.
+- `README.md` — overview + headline examples.
+- `CHANGELOG.md` — record user-visible changes.
+
+## Workflow
+
+1. **Find every doc touching the changed surface**:
+
+   ```bash
+   grep -rn "methodOrOption" docs/ README.md
+   ```
+
+2. **Verify each example against the real API** — signatures, option names,
+   return types, and enum cases must match `src/Fetch` and `CODE_MAP.md`. Common
+   drift: renamed options, changed defaults (retry/timeout/redirect/cache),
+   helper signatures (`fetch`, `fetch_stream`, `fetch_sse`, verb helpers), and
+   streaming/SSE consumption patterns.
+3. **Update `CODE_MAP.md`** if the public surface itself changed — it is the
+   map other docs and tests rely on.
+4. **Keep examples safe**: no real secrets/tokens/hosts; show TLS-on and
+   redaction-aware patterns; don't demonstrate `verify => false` as a default.
+5. **Add a `CHANGELOG.md`** entry for user-visible changes.
+6. **Build**:
+
+   ```bash
+   npm run build
+   rm -rf docs/.vitepress/.temp   # remove generated temp before committing
+   ```
+
+## Verification
+
+- `npm run build` succeeds; no generated `docs/.vitepress/.temp` (or `dist`/
+  `cache`) left staged.
+- Every changed/added public symbol has matching docs; examples run against the
+  current API.
+- `CODE_MAP.md` and `CHANGELOG.md` reflect the change.
+
+## Red flags — stop
+
+- An example uses a signature/option/default that no longer exists.
+- Docs claim a security guarantee the code doesn't provide (e.g. SSRF
+  protection, auto-redaction of a field that isn't redacted).
+- Committing `docs/.vitepress/dist`, `cache`, or `.temp`.

--- a/.claude/skills/fetch-php-http-security-review/SKILL.md
+++ b/.claude/skills/fetch-php-http-security-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: fetch-php-http-security-review
+description: Security review for Fetch PHP's HTTP behavior — SSRF, header/credential leakage, redirect and proxy handling, TLS verification, logging/debug redaction, cache isolation, and unsafe URI handling. Use when changing URL/URI handling, auth, redirects, proxies, TLS, logging/profiling, caching, or middleware/events.
+---
+
+# Fetch PHP HTTP security review
+
+Read-only, adversarial review. Assume attacker-controlled URLs, headers, and
+response bodies. Report each finding as `file:line` → concrete attack → fix.
+
+## When to use
+
+Any change to: URI building/validation (`HandlesUris`), auth
+(`withBearerToken`/`withBasicAuth`, `Authorization`), redirects, proxies, TLS
+(`verify`, `cert`, `ssl_key`), logging/debug/profiling redaction
+(`LoggingMiddleware`, `DebugInfo`, `ProfilerBridge`), caching
+(`CacheKeyGenerator`, `is_shared_cache`), DNS/pooling, or middleware/events.
+
+## Threats to check
+
+1. **SSRF / unsafe URLs.** `HandlesUris` validates *format* only (rejects
+   whitespace, requires a base URI for relative paths) — it does **not** block
+   private/link-local/metadata hosts or restrict schemes beyond
+   `FILTER_VALIDATE_URL`. Flag any new path where user input reaches a request
+   URL, base URI, redirect target, or proxy without the caller opting into
+   host/scheme restrictions. Do not claim the library prevents SSRF.
+2. **Credential & header leakage.** Auth headers, bearer/basic tokens, cookies,
+   proxy credentials, and query-string secrets must never appear unredacted in
+   logs, `DebugInfo` snapshots, profiler output, exception messages, or docs
+   examples. Verify redaction covers new sinks. Prefer marking secret-bearing
+   parameters `#[\SensitiveParameter]` so they are scrubbed from stack traces.
+3. **Redirect behavior.** Check whether headers (especially `Authorization`/
+   `Cookie`) are forwarded across host/scheme changes on redirect, and whether
+   redirect count/limits are enforced. Cross-origin credential forwarding is a
+   leak.
+4. **TLS.** Verification must stay on by default; a change that sets
+   `verify => false`, weakens cert checks, or exposes an easy "disable TLS"
+   default is a fail-open regression.
+5. **Cache isolation.** `CacheKeyGenerator` must incorporate the right `vary`
+   dimensions; a shared cache (`is_shared_cache`) must not serve one user's
+   authorized response to another. Never cache responses keyed without auth
+   context when auth affects the body.
+6. **Header/URI correctness.** Compare header names case-insensitively and
+   locale-independently; fail *closed* on validation errors (`preg_match`
+   returning `false`), never fail open. Watch for CRLF/whitespace injection into
+   headers or URIs and request-smuggling-style ambiguity.
+7. **Response body handling.** Untrusted bodies (JSON/XML) parsed safely; no
+   unbounded buffering of attacker-controlled streams (see
+   `fetch-php-performance-review`).
+
+## Verification
+
+- Trace one concrete attacker input end-to-end to the sink for each finding.
+- Confirm redaction with a test asserting the secret is absent from output.
+- `NO_NETWORK=1 composer check` still green after any hardening.
+
+## Red flags — stop and escalate
+
+- A new default that disables TLS verification or follows redirects with auth.
+- A secret rendered in a log/debug/exception/test fixture/doc example.
+- Cache keys or vary logic that could cross user/auth boundaries.
+- Validation that fails open, or trusts `filter_var` alone as an SSRF control.

--- a/.claude/skills/fetch-php-implement-change/SKILL.md
+++ b/.claude/skills/fetch-php-implement-change/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: fetch-php-implement-change
+description: Implement a feature or bug fix in Fetch PHP safely and incrementally — locate related code, define expected behavior, change the smallest surface, add PHPUnit tests, update docs, and run the local gates. Use when asked to add functionality, change behavior, or fix a defect in src/Fetch.
+---
+
+# Implement a change in Fetch PHP
+
+Follow [AGENTS.md](../../../AGENTS.md) for commands, conventions, and boundaries.
+Use [CODE_MAP.md](../../../CODE_MAP.md) to find the real public surface.
+
+## When to use
+
+Any code change under `src/Fetch/` — new option, new helper, new middleware/event,
+bug fix, refactor. For pure test work use `fetch-php-test-development`; for
+diagnosing a failing test/CI use `fetch-php-debug-failure`.
+
+## Workflow
+
+1. **Locate the seam.** Grep `CODE_MAP.md` and `src/Fetch/` for the feature.
+   Most request behavior flows through `ClientHandler` + its `Concerns/` traits
+   and `Support/RequestOptions` / `RequestContext`. Identify which trait or class
+   owns the behavior before touching anything.
+2. **Define expected behavior** in one or two sentences, including error and edge
+   cases (empty/invalid input, async vs sync, streaming, cache/no-cache).
+3. **Check public-API impact.** If the change touches a public class, interface,
+   method signature, helper in `helpers.php`, enum case, exception type, or a
+   default (retry/timeout/redirect/cache), run `fetch-php-public-api-review`
+   first and get maintainer sign-off before a breaking change.
+4. **Implement the smallest change** that satisfies the behavior. New files get
+   `declare(strict_types=1);` and match the surrounding style. Reuse existing
+   option normalization (`RequestOptions`) and defaults (`Defaults`,
+   `RetryDefaults`) rather than re-deriving them.
+5. **Add/extend tests** (`fetch-php-test-development`): a failing-first test for
+   bugs, positive + negative paths for features. Keep them offline and
+   deterministic.
+6. **Update docs** when behavior or the API changed (`fetch-php-documentation-sync`)
+   and add a `CHANGELOG.md` entry.
+7. **Run the gates**, narrowest first:
+
+   ```bash
+   ./vendor/bin/phpunit --filter=<yourTest>
+   composer fix
+   NO_NETWORK=1 composer check
+   ```
+
+## Verification
+
+- `composer check` passes (PHPStan level 6, Duster, full PHPUnit).
+- New/changed behavior is covered by a test that fails without your change.
+- No unrelated dependency, config, or formatting churn in the diff.
+- Docs/CHANGELOG updated if the public API or behavior changed.
+
+## Red flags — stop and reconsider
+
+- You added a `phpstan.neon` `ignoreErrors` entry to silence a real type problem.
+- The change alters a default (retry/timeout/redirect/cache) or a public
+  signature without BC analysis and maintainer approval.
+- A test needs the network, `sleep()`, or wall-clock timing to pass.
+- The fix grows to touch many files/subsystems — split it into reviewable units
+  and confirm the approach first.

--- a/.claude/skills/fetch-php-performance-review/SKILL.md
+++ b/.claude/skills/fetch-php-performance-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: fetch-php-performance-review
+description: Review Fetch PHP for resource and performance safety — connection reuse/pooling, buffering vs streaming, memory use, retry amplification, promise lifecycle, listener/stream/connection leaks, and event-loop blocking. Use when changing Pool, streaming, retries, async/promises, events, or caching.
+---
+
+# Fetch PHP performance & resource review
+
+Read-only review focused on resource lifetimes and throughput, not micro-opts.
+
+## When to use
+
+Changes to `Pool/` (`ConnectionPool`, `HostConnectionPool`, `Connection`,
+`DnsCache`, `Http2Configuration`), streaming (`StreamedResponse`, `EventSource`),
+`ManagesRetries`/`RetryStrategy`, `ManagesPromises`, `ManagesEvents`, or caching.
+
+## What to check
+
+1. **Connection reuse & pooling.** Connections are returned to the pool
+   (`releaseConnection`) on both success and error paths; `isReusable()` /
+   keep-alive respected; per-host and idle limits enforced; no unbounded pool
+   growth. Warmup counts don't leak eager connections.
+2. **Streaming vs buffering.** `StreamedResponse` bodies stay unbuffered —
+   consumed via `stream()`/`lines()`, never fully read into memory unless
+   `buffer()` is explicitly called. Flag any change that reads an entire
+   attacker- or size-unbounded body into a string.
+3. **Memory.** No accumulation of full response bodies, recorded requests, or
+   debug snapshots across many requests; bounded caches (`MemoryCache` max
+   items, `FileCache` size pruning) stay bounded.
+4. **Retry amplification.** Retries are capped (`RetryDefaults`), delays are
+   bounded with jitter (`MAX_DELAY_MS`), and only idempotent/retryable statuses
+   trigger retries. Watch for retry-on-every-error or nested retry layers
+   (handler + middleware) multiplying attempts (retry storm).
+5. **Promise lifecycle.** Every async path resolves or rejects exactly once;
+   rejections are handled; no dangling promises or timeouts that leak. Timeouts
+   surface as the documented exception, not a silent hang.
+6. **Listeners & leaks.** Event listeners and `on_redirect`/hook callbacks
+   aren't registered per-request without cleanup (listener accumulation);
+   streams and file handles (`FileCache`, recordings) are closed.
+7. **Event-loop blocking.** No synchronous/blocking calls (`sleep`, blocking
+   I/O, `gethostbyname` on the hot path without cache) inside async execution
+   that would stall the ReactPHP loop.
+
+## Verification
+
+- For pooling/stream/promise changes, point to where the resource is released/
+  closed on *every* path (success, exception, timeout, cancellation).
+- Add or identify a test proving bounded behavior (e.g. capped retries, released
+  connections) where feasible; keep it deterministic.
+
+## Red flags — stop
+
+- A body read fully into memory on the streaming path.
+- Retries/delays without a cap, or retrying non-idempotent requests by default.
+- A promise path that can neither resolve nor reject (hang), or double-resolve.
+- Connections/handles/listeners created without a matching release/close.

--- a/.claude/skills/fetch-php-public-api-review/SKILL.md
+++ b/.claude/skills/fetch-php-public-api-review/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: fetch-php-public-api-review
+description: Assess the semantic-versioning and backward-compatibility impact of a Fetch PHP change — public classes/interfaces/method signatures, global helpers, enum cases, exception behavior, PSR contracts, and default values. Use before changing any public surface or default, and to classify a release as patch/minor/major.
+---
+
+# Fetch PHP public-API & semver review
+
+Read-only analysis. Output a BC classification (**patch / minor / major**) with
+the exact `file:line` for each affected symbol and the migration cost.
+
+## When to use
+
+Before changing anything in the public surface, or when deciding the next
+version. Public surface = everything a consumer can depend on:
+
+- Public/protected members of non-`@internal` classes and all `Interfaces/`.
+- Global helpers in `src/Fetch/Support/helpers.php` (`fetch`, `fetch_client`,
+  `get`/`post`/`put`/`patch`/`delete`, `fetch_stream`, `fetch_sse`, async
+  bridges).
+- `Enum/` cases and their helper methods (`Method`, `ContentType`, `Status`).
+- Exception types and their externally visible behavior (`ClientException`,
+  `NetworkException`, `RequestException`, `HttpException`).
+- Response/stream/SSE semantics and PSR-7/PSR-18/PSR-3 conformance.
+- **Defaults**: retries (`RetryDefaults`), timeouts (`Defaults`), redirects,
+  caching, option precedence in `RequestOptions`.
+- Supported PHP versions and Composer constraints.
+
+## Classification rules
+
+- **MAJOR (breaking)** — remove/rename a public symbol; change a method
+  signature incompatibly (params, types, return); remove/rename an enum case;
+  change thrown exception type; change a default that alters observed behavior
+  (e.g. retry count, timeout, redirect following, cache on/off); raise the
+  minimum PHP version or tighten a dependency constraint; break a PSR contract.
+- **MINOR** — add a new public method/class/helper/enum case; add an optional
+  parameter with a safe default; widen accepted input; add a new opt-in option.
+- **PATCH** — internal-only fix with no observable public change.
+
+Guzzle's parameter-addition rule applies: prefer adding new **optional**
+parameters (or an options array) over changing existing signatures.
+
+## Workflow
+
+1. Diff the public surface: `git diff main...HEAD -- src/Fetch`.
+2. For each changed public symbol, decide added / changed / removed and map to
+   the rule above. Signature/enum/exception/default changes are the usual traps.
+3. If any change is MAJOR, **stop** — require explicit maintainer approval and a
+   documented migration path; do not ship it autonomously.
+4. Produce: classification, affected symbols (`file:line`), consumer impact,
+   required migration notes, and whether tests/docs/CHANGELOG cover it.
+
+## Verification
+
+- Every affected public symbol is listed with its BC verdict.
+- Deprecations (not removals) are used where a graceful path exists.
+- CHANGELOG + docs describe any minor/major change; a migration note exists for
+  major changes.
+
+## Red flags — stop
+
+- A signature/default/enum/exception change slipped in as a "fix" with no BC note.
+- Minimum PHP or a dependency constraint changed without justification.
+- A PSR-7/18/3 method's contract weakened.

--- a/.claude/skills/fetch-php-release/SKILL.md
+++ b/.claude/skills/fetch-php-release/SKILL.md
@@ -5,8 +5,15 @@ description: Prepare, publish, verify, and recover Fetch PHP releases through Gi
 
 # Fetch PHP Release
 
+See [AGENTS.md](../../../AGENTS.md) for repository commands and Git boundaries.
+This skill covers release-specific procedure only.
+
 ## Core Rules
 
+- **Never release autonomously.** Cutting a tag, creating a GitHub Release,
+  updating Packagist, or moving a tag are outward-facing, hard-to-reverse
+  actions — do them only on explicit maintainer instruction for a specific
+  version, and confirm the version before pushing anything.
 - Treat stable Packagist versions as immutable. After Packagist observes a stable tag, never move that tag to new code.
 - If a published stable tag points at the wrong commit, restore it to the previously published commit and tag a new patch release for the fix.
 - Follow the repository's tag convention: numeric tags such as `3.5.1`, not `v3.5.1`.
@@ -58,12 +65,14 @@ rm -rf docs/.vitepress/.temp
 
 5. Commit.
 
+Stage only the files this release actually changed — inspect first with
+`git status --short`, then add them explicitly (do not `git add -A`):
+
 ```bash
-git add CHANGELOG.md composer.json .github/workflows/packages.yml .github/SUPPORT.md docs/guide/installation.md src/Fetch/Cache/CacheControl.php
+git status --short
+git add CHANGELOG.md   # plus any other files this release genuinely touched
 git commit -m "Prepare vX.Y.Z release"
 ```
-
-Only stage files that actually changed.
 
 6. Create an annotated numeric tag.
 

--- a/.claude/skills/fetch-php-test-development/SKILL.md
+++ b/.claude/skills/fetch-php-test-development/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: fetch-php-test-development
+description: Write and run PHPUnit 11 tests for Fetch PHP following repo conventions — unit vs integration placement, Mockery and MockServer, snake_case test methods, deterministic async/timing tests, and offline (no-network) execution. Use when adding or fixing tests, or when a change needs coverage.
+---
+
+# Fetch PHP test development
+
+Follow the Testing section of [AGENTS.md](../../../AGENTS.md).
+
+## When to use
+
+Adding coverage for a feature/fix, writing a regression test, or making an
+existing test deterministic. For diagnosing *why* a test fails, use
+`fetch-php-debug-failure`.
+
+## Conventions
+
+- **PHPUnit 11**, namespace `Tests\`. Files end in `*Test.php`.
+- **Test methods are `snake_case`** (`public function test_it_does_x(): void`) —
+  enforced by `pint.json`; camelCase will fail `composer lint`.
+- Placement: `tests/Unit/` for isolated class behavior, `tests/Integration/`
+  for cross-component flows (events, middleware, streaming, concurrency).
+  Reusable fakes go in `tests/Mocks/` (excluded from the suite and PHPStan).
+- Extend `Tests\TestCase` when you touch global state — it resets
+  `GlobalServices` in `tearDown`. Also reset `MockServer::resetInstance()` and
+  `fetch_client(reset: true)` when used. `src/Fetch/Support` is excluded from
+  coverage.
+
+## Faking HTTP (never hit the network)
+
+Choose the lightest fake that fits:
+
+- **`Fetch\Testing\MockServer`** — `MockServer::fake([...])`, `MockResponse`,
+  `MockResponseSequence`, `preventStrayRequests()`, and `assertSent*` helpers.
+  Best for end-to-end handler/helper behavior.
+- **Guzzle `MockHandler`** injected via a custom client for transport-level
+  control.
+- **Mockery** for collaborators (loggers, profilers, dispatchers).
+
+## Deterministic async & timing
+
+- Never assert on wall-clock durations or use `sleep()`. Inject/await promises
+  and drive the event loop deterministically.
+- Test retry logic through `RetryStrategy` with fixed inputs; assert on the
+  computed delay/`isRetryable*` results, not real elapsed time.
+- Cover cancellation, timeout, and rejection paths, and exceptions crossing
+  async boundaries.
+
+## Workflow
+
+1. Write the test first for a bug (it must fail before the fix).
+2. Run it focused: `./vendor/bin/phpunit --filter=test_your_case`.
+3. Broaden: `composer test:unit` or `composer test:integration`.
+4. Full offline gate: `NO_NETWORK=1 composer test`, then `composer lint`.
+
+## Red flags — stop
+
+- The test only passes with real network access or specific timing.
+- Shared singletons leak between tests (missing reset → order-dependent flake).
+- A camelCase test method name (lint will reject it).
+- Asserting implementation details that would break on a valid refactor.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
 
 categories:
   - title: "🚀 Features"
@@ -67,4 +67,4 @@ template: |
 
   $CHANGES
 
-  **Full Changelog**: https://github.com/Thavarshan/fetch-php/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/Thavarshan/fetch-php/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: "$RESOLVED_VERSION"
+name-template: "v$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 
 categories:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ docs/.vitepress/dist
 docs/.vitepress/cache
 /duster_*
 docs/.obsidian/*
+
+# AI agent local/personal config (keep shared config committed)
+.claude/settings.local.json
+CLAUDE.local.md
+.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,199 @@
-# Repository Guidelines
+# AGENTS.md
 
-## Project Structure & Module Organization
+Canonical, vendor-neutral instructions for AI coding agents working in the
+**Fetch PHP** repository. Keep this file the single source of truth: other agent
+configs (Claude Code, Codex, etc.) should reference it rather than restate it.
 
-- `src/Fetch/` — library source (PSR-4: `Fetch\`), organized by `Enum/`, `Http/`, `Interfaces/`, `Traits/`, `Support/`, etc.
-- `tests/` — PHPUnit tests (`Unit/`, `Integration/`, `Mocks/`). Files end with `*Test.php`.
-- `bin/` — helper scripts: `lint.sh`, `fix.sh`, `test.sh` (invoked via Composer scripts).
-- `docs/` — VitePress documentation site (see `package.json` scripts).
-- Key configs: `composer.json`, `phpunit.xml.dist`, `phpstan*.neon`, `pint.json`.
+If anything here conflicts with the code, the code wins — fix the drift here in
+the same change.
 
-## Build, Test, and Development Commands
+## Project
 
-- `composer install` — install PHP dependencies.
-- `composer test` — run PHPUnit. Examples: `composer test -- --coverage`, `composer test -- --filter=ResponseTest`.
-- `composer lint` — static analysis + style checks (Duster/Pint, PHPStan, syntax).
-- `composer fix` — auto-fix coding style issues.
-- Docs: `npm run dev` (live docs), `npm run build` (static site), `npm run preview`.
+Fetch PHP (`jerome/fetch-php`) is a modern PHP HTTP client that brings the
+JavaScript `fetch` experience to PHP, built on top of Guzzle. It provides a
+`fetch()`-style API plus verb helpers, async/await via ReactPHP + `jerome/matrix`,
+streaming and Server-Sent Events, RFC 7234 HTTP caching, connection pooling,
+middleware, lifecycle events, retries, and full PSR-7/PSR-18/PSR-3 compliance.
 
-## Coding Style & Naming Conventions
+The public GitHub repository is `Thavarshan/fetch-php`; the Packagist package is
+`jerome/fetch-php`.
 
-- PHP ≥ 8.3. Declare `strict_types=1` in new files.
-- PSR-12 aligned; 4-space indentation; single quotes for strings; ordered imports.
-- Namespaces follow PSR-4 under `Fetch\...`; file name matches class.
-- PHPUnit method casing: snake_case (see `pint.json`).
-- Before committing, run `composer fix` and ensure `composer lint` passes.
+## Architecture
 
-## Testing Guidelines
+Read [CODE_MAP.md](CODE_MAP.md) for the concrete public surface before making
+non-trivial changes. High-level layout under `src/Fetch/` (PSR-4 root `Fetch\`):
 
-- Framework: PHPUnit 11; mocking via Mockery (see `tests/Mocks/`).
-- Place unit tests in `tests/Unit/`, integration tests in `tests/Integration/`.
-- Naming: `ClassOrFeatureTest.php`; each test method asserts one behavior.
-- Coverage: include tests for new code paths and regressions; use `--coverage` locally if Xdebug is available.
+- `Http/` — `Client` (PSR-18), `ClientHandler` (fluent engine), `Request`,
+  `Response`, `StreamedResponse`, `EventSource`, `ServerSentEvent`,
+  `MiddlewarePipeline`.
+- `Concerns/` — traits composed into `ClientHandler`: `ConfiguresRequests`,
+  `HandlesUris`, `PerformsHttpRequests`, `ManagesPromises`, `ManagesRetries`,
+  `ManagesMiddleware`, `ManagesEvents`, `ManagesConnectionPool`,
+  `ManagesDebugAndProfiling`, `HandlesMocking`.
+- `Enum/` — `Method`, `ContentType`, `Status`.
+- `Cache/` — RFC 7234 caching: `CacheManager`, `CacheControl`,
+  `CacheKeyGenerator`, `CachedResponse`, `MemoryCache`, `FileCache`.
+- `Pool/` — `ConnectionPool`, `HostConnectionPool`, `Connection`, `DnsCache`,
+  `Http2Configuration`, `PoolConfiguration`.
+- `Events/` — `EventDispatcher` and lifecycle events.
+- `Middleware/` — built-in `AddHeadersMiddleware`, `LoggingMiddleware`.
+- `Exceptions/` — `ClientException`, `NetworkException`, `RequestException`,
+  `HttpException`.
+- `Support/` — `RequestOptions`, `RequestContext`, `Defaults`, `RetryDefaults`,
+  `RetryStrategy`, `GlobalServices`, profiling/debug helpers, and
+  `helpers.php` (global functions).
+- `Testing/` — `MockServer`, `MockResponse`, `MockResponseSequence`, `Recorder`.
+- `Interfaces/` — contracts; `Traits/` — immutability traits.
 
-## Commit & Pull Request Guidelines
+## Environment
 
-- Commits: concise, imperative mood. Example: `Add retry backoff jitter`.
-- PRs: describe Purpose and Approach, link issues, checklists per `.github/PULL_REQUEST_TEMPLATE.md`.
-- Requirements: green CI (tests, lint), updated docs/snippets when API changes, add tests for fixes/features.
+- **PHP `^8.3`.** CI runs **8.3, 8.4, and 8.5** on Ubuntu, Windows, and macOS,
+  plus one `prefer-lowest` job (Ubuntu, 8.3). Local dev pins 8.4 (`.phpvmrc`).
+- Requires `ext-pcntl` (ignored on Windows, along with `ext-posix`).
+- Runtime deps: `guzzlehttp/guzzle ^7.9`, `guzzlehttp/psr7 ^2.7`,
+  `jerome/matrix ^3.4`, `react/event-loop ^1.5`, `react/promise ^3.2`,
+  `psr/http-message ^1|^2`, `psr/log ^1|^2|^3`.
+- `composer.json` has **no `version` field** — versions come from Git tags.
+- `composer.lock` is not committed (this is a library).
 
-## Security & Configuration Tips
+## Commands (authoritative — from `composer.json` / `package.json`)
 
-- Do not commit secrets or tokens. Prefer environment-driven config in tests.
-- Network-dependent tests should use mocks/fakes; avoid external calls in CI.
-- Targeted PHP versions are enforced in `.phpvmrc` and CI; verify locally.
+| Task | Command | Actually runs |
+| --- | --- | --- |
+| Install | `composer install` | — |
+| Style check | `composer lint` | `duster lint src` |
+| Auto-fix style | `composer fix` | `duster fix src` |
+| Static analysis | `composer analyse` | `phpstan analyse` (`phpstan.neon`, level 6) |
+| All tests | `composer test` | `phpunit --no-coverage` |
+| Unit only | `composer test:unit` | `phpunit --no-coverage tests/Unit` |
+| Integration only | `composer test:integration` | `phpunit --no-coverage tests/Integration` |
+| Coverage | `composer test:coverage` | `phpunit` with Xdebug (needs `ext-xdebug`) |
+| Full gate | `composer check` | `analyse`, then `lint`, then `test` |
+| Docs (dev) | `npm run dev` | `vitepress dev docs` |
+| Docs (build) | `npm run build` | `vitepress build docs` |
 
-## CI/No-Network Environments
+- Focused runs: `./vendor/bin/phpunit --filter=some_method` or
+  `./vendor/bin/phpunit tests/Unit/SomeTest.php`. Passing args through Composer
+  also works: `composer test -- --filter=some_method`.
+- There is **no `bin/` script directory**; invoke the Composer/npm scripts above.
+- `composer lint` does **not** run PHPStan — run `composer analyse` for that.
 
-- Skip the network-dependent unit test by setting `NO_NETWORK=1`.
-- Example: `NO_NETWORK=1 composer test`.
-- Keep tests deterministic: mock HTTP instead of real network I/O where possible.
+## Coding conventions
+
+- Declare `declare(strict_types=1);` in every new PHP file.
+- PSR-12 aligned, 4-space indent, single quotes, ordered imports (`const`,
+  `class`, `function`), enforced by **Duster** (Pint + PHP CS Fixer +
+  PHP_CodeSniffer) via `pint.json`. Run `composer fix` before committing.
+- PSR-4 namespaces under `Fetch\...`; one class per file, filename matches class.
+- Keep PHPStan level 6 clean (`composer analyse`); prefer real type fixes over
+  new entries in `phpstan.neon` `ignoreErrors`.
+- Match the style, naming, and comment density of the surrounding file.
+
+## Testing
+
+- **PHPUnit 11**; mocks via **Mockery**. Test namespace `Tests\`.
+- Unit tests → `tests/Unit/`, integration tests → `tests/Integration/`,
+  shared fakes → `tests/Mocks/` (excluded from the suite and PHPStan).
+- Files end in `*Test.php`; test **methods are `snake_case`** (e.g.
+  `test_it_builds_the_uri`) — enforced by `pint.json`.
+- Tests may extend `Tests\TestCase` (resets `GlobalServices` in `tearDown`) to
+  stay isolated; reset shared singletons (`GlobalServices`, `MockServer`,
+  `fetch_client(reset: true)`) when you touch global state.
+- **Tests must not make real network calls.** Use `Fetch\Testing\MockServer`,
+  Mockery, or a Guzzle `MockHandler`. CI exports `NO_NETWORK=1` as a guard; no
+  test currently branches on it, so do not rely on it to gate live I/O — just
+  keep every test offline and deterministic.
+- Avoid `sleep()`/wall-clock assertions; test timing, retry, cancellation, and
+  error paths with fakes and injected clocks/strategies.
+- Add a regression test with every bug fix. Coverage excludes
+  `src/Fetch/Support`.
+
+## Public API & backward compatibility
+
+This is a widely used library on semantic versioning. Treat as
+**backward-compatibility-sensitive**: public classes/interfaces, public method
+signatures, global helpers in `helpers.php`, enum cases, exception types and
+their externally visible behavior, response/stream semantics, and the defaults
+for retries, timeouts, redirects, caching, and PSR-7/PSR-18 behavior.
+
+Changing any of these requires: impact analysis, a BC classification
+(patch / minor / major), tests, docs, and a CHANGELOG entry. Breaking or
+release-sensitive changes need explicit maintainer approval — never ship them
+autonomously.
+
+## Dependencies
+
+Do not add or bump dependencies for convenience. A dependency change needs
+justification, a license/maintenance/security check, a supported-PHP-version
+check, `prefer-lowest` consideration, and CHANGELOG/docs notes. Never add
+dependencies for AI tooling.
+
+## Documentation
+
+When behavior or the public API changes, update the VitePress docs under
+`docs/` (and `README.md` where relevant), verify examples against the real API,
+and run `npm run build`. Remove any generated `docs/.vitepress/.temp` before
+committing.
+
+## Security boundaries
+
+- Never commit or print secrets, tokens, or credentials — not in code, tests,
+  fixtures, logs, docs examples, or error output.
+- Treat as sensitive: user-supplied URLs, redirects, proxies, auth headers,
+  cookies, TLS options, cache keys, DNS caching, connection pooling, request/
+  response bodies, multipart uploads, streaming, retries, middleware, and
+  events. Keep auth/`Authorization`/`Cookie` values redacted in logging,
+  profiling, and debug snapshots.
+- `HandlesUris` validates URI *format* only — it does **not** block private/
+  internal hosts. SSRF hardening is the caller's responsibility; don't imply
+  otherwise in docs, and flag anywhere user input reaches a request URL.
+
+## Async & resource safety
+
+Watch for leaked/unresolved promises, unhandled rejections, blocked event
+loops, unbounded concurrency, retry storms, duplicate callbacks, listener
+accumulation, and stream/connection leaks. Respect cancellation and timeout
+behavior; ensure exceptions crossing async boundaries are handled.
+
+## Git & pull-request boundaries
+
+- Work on a branch (`feature/*`, `fix/*`, `refactor/*`); base is `main`
+  (`develop` also exists). Conventional Commits (`feat:`, `fix:`, `docs:`, …).
+- **Never** run `git reset --hard`, `git clean -fd`, `git push --force`, or
+  `git push --force-with-lease`. Do not discard unrelated uncommitted work.
+- Do not push, open PRs, create/move tags, publish packages, cut GitHub
+  releases, or trigger Packagist without explicit maintainer instruction.
+  Release procedure lives in the `fetch-php-release` skill.
+
+## Agent skills
+
+Task workflows live once in `.claude/skills/<name>/SKILL.md` (the canonical
+source). Claude Code discovers them natively; Codex and other tools read this
+list and open the referenced file on demand — there is no second copy to drift.
+Use the skill that matches the task:
+
+- `fetch-php-implement-change` — implement a feature/bug fix under `src/Fetch`.
+- `fetch-php-test-development` — write/fix PHPUnit tests.
+- `fetch-php-debug-failure` — diagnose a failing test or behavior.
+- `fetch-php-code-review` — review a diff/branch/PR.
+- `fetch-php-http-security-review` — SSRF, leakage, redirects, TLS, cache.
+- `fetch-php-performance-review` — pooling, streaming, retries, async, leaks.
+- `fetch-php-public-api-review` — semver/BC impact of a public-surface change.
+- `fetch-php-ci-triage` — diagnose failing GitHub Actions.
+- `fetch-php-documentation-sync` — keep docs/README/CODE_MAP aligned with code.
+- `fetch-php-release` — prepare/recover a release (maintainer-approved only).
+
+Claude Code also ships path-scoped rules (`.claude/rules/`), specialist
+subagents (`.claude/agents/`), conservative permissions, and a destructive-command
+guard hook. See [docs/ai/README.md](docs/ai/README.md) for the full map and how
+to validate the setup (`composer ai:validate`).
+
+## Definition of done
+
+1. `composer fix` applied; `composer lint` clean.
+2. `composer analyse` clean (PHPStan level 6).
+3. Relevant tests added/updated; `composer test` green (`composer check` for the
+   full gate).
+4. Docs/CHANGELOG updated when behavior or the public API changed.
+5. No secrets, no unrelated dependency or config churn, no destructive Git.
+6. Diff reviewed and understood.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Release Notes
 
-## [Unreleased](https://github.com/Thavarshan/fetch-php/compare/3.8.0...HEAD)
+## [Unreleased](https://github.com/Thavarshan/fetch-php/compare/3.8.1...HEAD)
+
+## [v3.8.1](https://github.com/Thavarshan/fetch-php/compare/3.8.0...3.8.1) - 2026-07-23
+
+Development-tooling and documentation release. **No runtime library changes** —
+the public API, behavior, and dependencies are unchanged.
+
+### Added
+
+- **Cross-agent AI development configuration** targeting Claude Code and OpenAI
+  Codex while staying compatible with the `AGENTS.md` / Agent Skills standard:
+  a canonical `AGENTS.md`, a `CLAUDE.md` that imports it, 10 task/review skills,
+  6 specialist subagents, 7 path-scoped rules, conservative `.claude/settings.json`
+  permissions with a destructive-command guard hook, a `docs/ai/` guide with
+  license-verified sources, and a dependency-free validator (`composer ai:validate`).
+
+### Changed
+
+- Corrected stale contributor/AI instructions against the repository: removed
+  references to a nonexistent `bin/` script directory, clarified that
+  `composer lint` runs Duster (PHPStan is `composer analyse`), documented the
+  PHP 8.3/8.4/8.5 CI matrix, aligned the `jerome/matrix ^3.4` constraint, and
+  clarified `NO_NETWORK=1` semantics.
 
 ## [v3.8.0](https://github.com/Thavarshan/fetch-php/compare/3.7.0...3.8.0) - 2026-07-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,129 +1,69 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code in this repository.
 
-## Core Commands
+The canonical, vendor-neutral instructions live in **AGENTS.md** — architecture,
+commands, conventions, testing, public-API rules, security boundaries, and the
+definition of done. Read them first; they are imported here:
 
-### Testing
+@AGENTS.md
 
-- **Run all tests**: `composer test`
-- **Run unit tests only**: `composer test:unit`
-- **Run integration tests only**: `composer test:integration`
-- **Run tests with coverage**: `composer test:coverage`
-- **Run specific test**: `./vendor/bin/phpunit tests/Unit/SomeTest.php`
-- **Run tests with filter**: `./vendor/bin/phpunit --filter=testMethodName`
+Everything below is **additive** Claude-specific guidance — it does not restate
+AGENTS.md. If the two ever disagree, AGENTS.md wins; fix the drift.
 
-### Code Quality
+## Plan first for risky work
 
-- **Lint code**: `composer lint` (runs Duster)
-- **Fix code style**: `composer fix` (runs Duster fix)
-- **Static analysis**: `composer analyse` (runs PHPStan)
-- **Run all checks**: `composer check` (lint + analyse + test)
+Enter **plan mode** before you edit when a task is likely to touch the public
+API or defaults (`src/Fetch/Interfaces/`, `Http/Client.php`, `Http/Response.php`,
+`Enum/`, `Support/helpers.php`, `Support/RequestOptions.php`, `Support/Defaults.php`,
+`Support/RetryDefaults.php`), spans multiple subsystems, or changes async,
+caching, streaming, pooling, retry, or security behavior. Trivial, localized
+fixes don't need a plan.
 
-### Installation & Setup
+## Skills — invoke the right one
 
-- **Install dependencies**: `composer install`
-- **Run with NO_NETWORK=1**: `NO_NETWORK=1 composer test` - For tests that shouldn't make network calls
+These project skills (`.claude/skills/`) encode the real workflows. Prefer them
+over improvising; they also drive Codex and other AGENTS.md-aware tools.
 
-## Architecture Overview
+| Work | Skill |
+| --- | --- |
+| Add a feature / fix a bug in `src/Fetch` | `fetch-php-implement-change` |
+| Write or fix PHPUnit tests | `fetch-php-test-development` |
+| A test or behavior is failing | `fetch-php-debug-failure` |
+| Review a diff / branch / PR | `fetch-php-code-review` |
+| URL/auth/redirect/TLS/logging/cache change | `fetch-php-http-security-review` |
+| Pool/stream/retry/async/event change | `fetch-php-performance-review` |
+| Any public surface or default change | `fetch-php-public-api-review` |
+| GitHub Actions is red | `fetch-php-ci-triage` |
+| Docs/README/examples need updating | `fetch-php-documentation-sync` |
+| Cut or recover a release (maintainer-approved) | `fetch-php-release` |
 
-**Fetch PHP** is a modern HTTP client library that brings JavaScript's fetch API experience to PHP, built on top of Guzzle HTTP.
+Path-scoped `.claude/rules/` load automatically when you open matching files
+(PHP source, tests, docs, workflows, public-API files) — you don't invoke them.
 
-### Core Structure
+## Subagents
 
-```text
-src/Fetch/
-├── Http/                    # Core HTTP components
-│   ├── Client.php          # Main HTTP client (PSR-18 compliant)
-│   ├── ClientHandler.php   # Handler for client operations
-│   ├── Request.php         # HTTP request wrapper
-│   └── Response.php        # HTTP response wrapper
-├── Concerns/               # Trait-based functionality
-│   ├── ConfiguresRequests.php    # Request configuration
-│   ├── HandlesUris.php          # URI handling
-│   ├── ManagesPromises.php      # Async promise management
-│   ├── ManagesRetries.php       # Retry logic
-│   └── PerformsHttpRequests.php # HTTP request execution
-├── Enum/                   # Type-safe enumerations
-│   ├── Method.php          # HTTP methods (GET, POST, etc.)
-│   ├── ContentType.php     # Content type constants
-│   └── Status.php          # HTTP status codes
-├── Support/
-│   └── helpers.php         # Global helper functions
-└── Interfaces/             # Contracts
-```
+Delegate to a specialist (`.claude/agents/`) to keep review evidence-based and
+read-only where appropriate:
 
-### Key Design Patterns
+- `php-library-maintainer` — implement a scoped change end to end.
+- `phpunit-test-engineer` — author/repair tests.
+- `http-security-reviewer` — adversarial HTTP/security review (read-only).
+- `public-api-reviewer` — semver/BC impact (read-only).
+- `documentation-reviewer` — docs-vs-code drift (read-only).
+- `ci-investigator` — triage failing GitHub Actions (read-only + `gh`).
 
-1. **Multiple API Styles**: Supports both JavaScript-like `fetch()` and traditional PHP helper functions (`get()`, `post()`, etc.)
+## Large or multi-part changes
 
-2. **Global Client Management**: Uses a singleton pattern via `fetch_client()` for application-wide configuration
+Split into reviewable units and confirm the approach before a wide edit. Never
+bundle a behavior change with a broad reformat. Run the narrowest check while
+iterating (`./vendor/bin/phpunit --filter=...`) and the full gate before saying
+done (`NO_NETWORK=1 composer check`).
 
-3. **Trait-based Architecture**: Core functionality split into focused traits for better separation of concerns
+## Verification behavior
 
-4. **PSR Compliance**: Implements PSR-18 (HTTP Client), PSR-7 (HTTP Messages), and PSR-3 (Logger)
-
-5. **Async/Promise Support**: Built on React PHP promises with `async()`, `await()`, `all()`, `race()` utilities
-
-### Helper Functions (src/Fetch/Support/helpers.php)
-
-- `fetch()` - Main JavaScript-like API
-- `fetch_client()` - Global client instance
-- HTTP method helpers: `get()`, `post()`, `put()`, `patch()`, `delete()`
-- Async utilities: `async()`, `await()`, `all()`, `race()`, `map()`, `batch()`, `retry()`
-
-## Development Guidelines
-
-### Code Style
-
-- Uses **Duster** (by Tighten) for code formatting
-- Configuration in `pint.json` (Laravel Pint rules)
-- Runs PHP CS Fixer and PHPStan under the hood
-- Enforces PSR-12 with custom rules
-
-### Testing Framework
-
-- **PHPUnit 11.5+** for unit testing (not Pest)
-- Test structure: `tests/Unit/`, `tests/Integration/`
-- Coverage reports generated with Xdebug
-- CI runs tests on PHP 8.3, 8.4 across Ubuntu, Windows, macOS
-- Helper functions (`src/Fetch/Support/`) excluded from coverage
-
-### Key Dependencies
-
-- **Guzzle HTTP** 7.9+ (underlying HTTP client)
-- **React components** (event-loop, promise) for async operations
-- **Jerome/Matrix** 3.3+ (utility library)
-
-### Branching Strategy
-
-- Main branch: `main`
-- Feature branches: `feature/*`, `fix/*`, `refactor/*`
-- Development branch: `develop`
-
-### Environment Variables
-
-- `NO_NETWORK=1` - Disables network calls in tests
-
-## Common Development Tasks
-
-### Adding New HTTP Methods
-
-1. Add enum value to `src/Fetch/Enum/Method.php`
-2. Add helper function in `src/Fetch/Support/helpers.php`
-3. Update `PerformsHttpRequests` trait if needed
-4. Add tests in `tests/Unit/`
-
-### Adding New Configuration Options
-
-1. Update `ConfiguresRequests` trait
-2. Add to options processing in helper functions
-3. Document in README examples
-4. Add tests for new option
-
-### Debugging Failed Tests
-
-- Check CI logs for specific PHP version failures
-- Run locally with same PHP version: `php -v`
-- Use `NO_NETWORK=1` for offline testing
-- Check coverage reports in `coverage/` directory
+- Don't claim a command passed unless you actually ran it; paste real failures.
+- After edits, run `composer fix`, then `composer analyse`, then the relevant
+  tests. `composer check` runs all three (analyse → lint → test).
+- Respect the Git/PR/release boundaries in AGENTS.md — no destructive Git, no
+  pushing/PRs/tags/releases without explicit maintainer instruction.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,33 @@ final class RequestTest extends TestCase
 - Update the changelog for significant changes
 - Consider adding documentation to the docs/ folder
 
+## AI-Assisted Contributions
+
+AI coding assistants are welcome, and this repository ships a shared
+configuration for them (see [docs/ai/README.md](docs/ai/README.md)). If you use
+one, these rules apply:
+
+- **You own the code.** AI-generated changes must meet the same review, testing,
+  and static-analysis bar as any other contribution. Understand every line you
+  submit — "the tool wrote it" is not a review.
+- **Same gates.** Run `composer fix`, `composer analyse`, and `composer test`
+  (or `composer check`) before opening a PR, exactly as for hand-written code.
+- **No secrets in prompts.** Never paste credentials, tokens, private data, or
+  proprietary code into an AI tool. Keep secrets out of code, tests, fixtures,
+  logs, and docs examples.
+- **Respect licenses.** Don't submit AI-produced content copied from
+  incompatible or source-available sources. Attribution for adapted material
+  goes in [docs/ai/SOURCES.md](docs/ai/SOURCES.md).
+- **Keep changes reviewable.** Split large AI-generated changes into small,
+  focused, reviewable commits. Don't bundle a behavior change with a broad
+  reformat.
+- **Preserve the public API.** Backward-compatibility-sensitive changes (public
+  classes, signatures, helpers, enums, exceptions, defaults) need the impact
+  analysis described in `AGENTS.md`; breaking changes need maintainer approval.
+
+Contributors and maintainers can validate the AI configuration itself with
+`composer ai:validate`.
+
 ## Issue Reporting
 
 ### Bug Reports

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "test:integration": "phpunit --no-coverage tests/Integration",
         "test:coverage": "XDEBUG_MODE=coverage phpunit --coverage-html=coverage --coverage-text --coverage-xml=coverage",
         "analyse": "phpstan analyse",
+        "ai:validate": "php tools/validate-ai-config.php",
         "check": [
             "@analyse",
             "@lint",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,10 @@ export default defineConfig({
     // IMPORTANT: Set canonical URL base to avoid duplicate content issues
     base: "/",
 
+    // Contributor-facing AI-tooling docs (docs/ai/**) are not part of the
+    // published user documentation site; they link to repo files outside docs/.
+    srcExclude: ["ai/**"],
+
     sitemap: {
         hostname: "https://fetch-php.thavarshan.com",
     },

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,138 @@
+# AI-assisted development in Fetch PHP
+
+This repository ships a cross-agent configuration so AI coding assistants work
+on Fetch PHP safely and consistently. It targets **Claude Code** and **OpenAI
+Codex** first, and stays compatible with any tool that understands `AGENTS.md`
+and the [Agent Skills](https://agentskills.io) standard.
+
+Contributors remain fully responsible for AI-assisted changes — see the
+AI-assisted contributions section in [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Supported tools & what they read
+
+| Tool | Reads | Notes |
+| --- | --- | --- |
+| **Claude Code** | `CLAUDE.md`, `.claude/rules/`, `.claude/skills/`, `.claude/agents/`, `.claude/settings.json`, hooks | `CLAUDE.md` imports `AGENTS.md` via `@AGENTS.md` |
+| **OpenAI Codex** | `AGENTS.md` (root + nested) | Discovers skills through the list in `AGENTS.md`; optional native `$skill` discovery via `.agents/skills/` (see below) |
+| **Other AGENTS.md tools** | `AGENTS.md` | Vendor-neutral instructions apply |
+
+## File map
+
+| Path | Purpose |
+| --- | --- |
+| `AGENTS.md` | **Canonical, vendor-neutral instructions** — the single source of truth (architecture, commands, conventions, testing, public-API rules, security, Git boundaries, definition of done). |
+| `CLAUDE.md` | Claude-specific, additive guidance. Imports `AGENTS.md`; adds plan-mode, skill routing, subagents, verification behavior. |
+| `CODE_MAP.md` | Concrete public-surface map; the contract docs and tests follow. |
+| `.claude/rules/*.md` | Path-scoped reminders that auto-load when a matching file is opened (`paths:` front matter). |
+| `.claude/skills/<name>/SKILL.md` | Task workflows (canonical copy). |
+| `.claude/agents/*.md` | Specialist subagents. |
+| `.claude/settings.json` | Shared, conservative permissions + the guard hook registration. |
+| `.claude/hooks/guard-destructive.sh` | Blocks destructive Git / catastrophic `rm`. |
+| `.claude/settings.local.json` | **Personal, git-ignored** — your own permission grants. |
+| `docs/ai/SOURCES.md` | External sources & license attribution. |
+| `tools/validate-ai-config.php` | The validator (`composer ai:validate`). |
+
+## Skills (when they activate)
+
+Skills live once under `.claude/skills/`. Claude Code loads their descriptions at
+startup and activates one when the task matches (or on `/skill-name`); Codex and
+other tools find them through the list in `AGENTS.md`.
+
+| Skill | Use when |
+| --- | --- |
+| `fetch-php-implement-change` | Adding a feature or fixing a bug in `src/Fetch`. |
+| `fetch-php-test-development` | Writing or fixing PHPUnit tests. |
+| `fetch-php-debug-failure` | A test or behavior is failing. |
+| `fetch-php-code-review` | Reviewing a diff/branch/PR. |
+| `fetch-php-http-security-review` | URL/auth/redirect/TLS/logging/cache changes. |
+| `fetch-php-performance-review` | Pool/stream/retry/async/event changes. |
+| `fetch-php-public-api-review` | Any public-surface or default change. |
+| `fetch-php-ci-triage` | GitHub Actions is red. |
+| `fetch-php-documentation-sync` | Docs/README/examples need updating. |
+| `fetch-php-release` | Preparing/recovering a release (maintainer-approved only). |
+
+## Subagents
+
+`php-library-maintainer` (implements changes), `phpunit-test-engineer` (tests),
+and the read-only reviewers `http-security-reviewer`, `public-api-reviewer`,
+`documentation-reviewer`, and `ci-investigator`. Reviewers have no Edit/Write
+tools — they report findings for a human or the maintainer agent to act on.
+
+## Permissions & safety
+
+`.claude/settings.json` is deliberately conservative:
+
+- **allow** — read-only and routine dev commands (`composer test/lint/analyse/
+  fix/check`, `phpunit`, `git status/diff/log`, `gh run/release view`, docs
+  build).
+- **ask** — anything outward-facing or state-changing (`git push`, `git tag`,
+  `git commit`, `gh release`, `composer require/update/remove`, `curl`).
+- **deny** — destructive Git (`reset --hard`, `clean -fd`, force push) and
+  reading secret files (`.env`, keys, `~/.ssh`, `~/.aws`).
+
+The `PreToolUse` hook (`.claude/hooks/guard-destructive.sh`) is defense-in-depth
+for the destructive-Git and catastrophic-`rm` cases. It is pure POSIX `sh` +
+`grep` (no `jq`/PHP/Node dependency), runs locally, makes no network calls, and
+transmits nothing.
+
+**Platform note:** the hook needs a POSIX shell. On Windows, Claude Code runs
+hooks through its bundled Git Bash, so it works there; the declarative
+permission rules apply on every platform regardless.
+
+Your personal grants belong in `.claude/settings.local.json` (git-ignored), not
+in the committed settings file. Never commit machine-specific paths.
+
+## Codex native skill discovery (optional)
+
+Codex reads `AGENTS.md` and will find the skills listed there. If you also want
+native `$skill-name` discovery in Codex, expose the canonical skills under
+`.agents/skills/` locally:
+
+```bash
+# macOS/Linux — symlink so there is still only one real copy
+ln -s ../.claude/skills .agents/skills
+```
+
+`.agents/skills` is git-ignored to prevent a committed duplicate. On Windows,
+symlinks need Developer Mode/Administrator, so either enable that or keep using
+the `AGENTS.md`-driven discovery (recommended default). Do not commit a second
+copy of any skill.
+
+## Validate the configuration
+
+```bash
+composer ai:validate      # or: php tools/validate-ai-config.php
+```
+
+It checks (no network, deterministic): required files exist; `CLAUDE.md`
+imports `@AGENTS.md`; every skill has valid, unique front matter with a name
+matching its directory; skills are referenced in `AGENTS.md` (Claude↔Codex
+sync); subagents/rules are well-formed; JSON parses; and no personal absolute
+paths or secret-looking strings are committed.
+
+## Adding a new skill
+
+1. Create `.claude/skills/<kebab-name>/SKILL.md` with front matter:
+
+   ```yaml
+   ---
+   name: <kebab-name>            # must equal the directory name
+   description: <what it does, and exactly when to use it>   # ≤1024 chars
+   ---
+   ```
+
+2. Write a concrete, executable workflow with verification steps and red-flag
+   stop conditions. Reference repository commands from `AGENTS.md`; don't invent
+   new ones or duplicate whole `AGENTS.md` sections.
+3. Add the skill to the list in `AGENTS.md` (required for Codex discovery and
+   for `composer ai:validate` to pass) and to the tables in `CLAUDE.md` and this
+   file.
+4. Run `composer ai:validate`.
+
+## Avoiding instruction drift
+
+- `AGENTS.md` is the single source of truth; `CLAUDE.md` and rules stay
+  additive. If they disagree with the code, fix them in the same change.
+- Update `CODE_MAP.md` when the public surface changes.
+- Record any adapted external material in `docs/ai/SOURCES.md`.
+- Run `composer ai:validate` before committing AI-config changes.

--- a/docs/ai/SOURCES.md
+++ b/docs/ai/SOURCES.md
@@ -1,0 +1,61 @@
+# AI configuration sources & attribution
+
+This file records every external source consulted while building Fetch PHP's
+AI-agent configuration, its license, and how it was used. The rule we followed:
+**adapt concepts in our own words; never vendor files verbatim; never copy
+source-available or proprietary content.** All Fetch PHP AI config in this repo
+is original prose written for this project.
+
+Research date: 2026-07-23.
+
+## Official standards (source of truth for syntax)
+
+| What | Source | Used for |
+| --- | --- | --- |
+| Claude Code memory & `@import` | `code.claude.com/docs/en/memory` | `CLAUDE.md` importing `@AGENTS.md`; `.claude/rules/` with `paths:` front matter |
+| Claude Code skills | `code.claude.com/docs/en/skills` | `.claude/skills/<name>/SKILL.md` structure & `name`/`description` rules |
+| Claude Code subagents | `code.claude.com/docs/en/sub-agents` | `.claude/agents/*.md` `name`/`description`/`tools`/`model` |
+| Claude Code settings & permissions | `code.claude.com/docs/en/settings`, `/permissions` | `.claude/settings.json` allow/ask/deny matchers |
+| Claude Code hooks | `code.claude.com/docs/en/hooks` | `PreToolUse` Bash guard hook contract |
+| Codex `AGENTS.md` | `learn.chatgpt.com/docs/agent-configuration/agents-md` | AGENTS.md as canonical, 32 KiB budget, nested discovery |
+| Codex skills | `learn.chatgpt.com/docs/build-skills` | Codex reads `.agents/skills/` (not `.claude/skills/`); `agents/openai.yaml` |
+| Agent Skills open standard | `agentskills.io/specification` | SKILL.md frontmatter (`name` must match dir; `description` ≤1024) |
+
+Key design consequence: Claude Code reads `.claude/skills/`, Codex reads
+`.agents/skills/`. To avoid divergent copies **and** fragile Windows symlinks, we
+keep one canonical skill set in `.claude/skills/` and reference it from
+`AGENTS.md` (which Codex and other AGENTS.md-aware tools read). `composer
+ai:validate` enforces that the two stay in sync.
+
+## Open-source repositories evaluated
+
+Licenses below were verified by inspecting each repo's `LICENSE`/`LICENSE.txt`
+or the GitHub license field on 2026-07-23.
+
+### Concepts adopted (adapted, not copied)
+
+| Repo | Inspected | License | Concepts adapted into | 
+| --- | --- | --- | --- |
+| [guzzle/guzzle](https://github.com/guzzle/guzzle) — the library Fetch PHP wraps | `AGENTS.md` (HEAD `604492e`, 2026-07-20) | MIT | `#[\SensitiveParameter]` on secret-bearing params; fail-closed validation; locale-independent header comparison; prefer additive optional params for BC → informed `http-security.md`, `php-style.md`, `public-api-and-semver.md`, `fetch-php-http-security-review`, `fetch-php-public-api-review` |
+| [trailofbits/skills](https://github.com/trailofbits/skills) | HEAD `cfe5d7b` | **CC-BY-SA-4.0 (copyleft)** — concepts only, no verbatim reuse | "fail-open defaults" detection; the "when to use / rationalizations to reject" skill shape → informed the *Red flags — stop* sections and `fetch-php-http-security-review` |
+| [anthropics/skills](https://github.com/anthropics/skills) | HEAD `1f630fd` | Per-skill (Apache-2.0 for `skill-creator`, `mcp-builder`, `claude-api`); **`docx`/`pdf`/`pptx`/`xlsx` are source-available — NOT used** | SKILL.md spec/structure & progressive-disclosure model → all skills |
+| [openai/skills](https://github.com/openai/skills) | 2026-07-14 | Per-skill Apache-2.0 (`security-best-practices`, `security-threat-model`) | threat-model skill structure → `fetch-php-http-security-review` |
+| [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) | HEAD `fefc407` | MIT | individual review/testing concepts → `fetch-php-code-review`, `fetch-php-test-development` (cherry-picked, not vendored) |
+| [algolia/algoliasearch-client-php](https://github.com/algolia/algoliasearch-client-php), [neuron-core/neuron-ai](https://github.com/neuron-core/neuron-ai) | 2026-07 | MIT | real-world examples of describing a Guzzle-based HTTP client to an agent → structure of `AGENTS.md` architecture section |
+
+### Referenced only (not sourced/copied)
+
+| Repo | License | Why not copied |
+| --- | --- | --- |
+| [openai/codex](https://github.com/openai/codex) | Apache-2.0 | Runtime, not config — used only to confirm the AGENTS.md convention |
+| [anthropics/claude-code](https://github.com/anthropics/claude-code) | Proprietary / source-available (no OSS license) | Product repo; conventions referenced via official docs, no material copied |
+| `anthropics/skills/{docx,pdf,pptx,xlsx}` | Source-available proprietary | Explicitly excluded — must never be copied or vendored |
+| [symfony/http-client](https://github.com/symfony/http-client) | MIT | Inspected — has no `AGENTS.md`/`CLAUDE.md`; nothing to source |
+
+## Keeping this current
+
+When you adapt anything new from an external source, add a row here with the
+repo, the commit/version inspected, its license, the concept adopted, whether it
+was copied/adapted/inspiration, and the local files it influenced. Copyleft
+(e.g. CC-BY-SA) and source-available/proprietary material must never be pasted
+verbatim.

--- a/tools/validate-ai-config.php
+++ b/tools/validate-ai-config.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Validates the Fetch PHP cross-agent AI configuration.
+ *
+ * Pure PHP, no Composer dependencies, no network. Run locally or in CI:
+ *
+ *     composer ai:validate      # or: php tools/validate-ai-config.php
+ *
+ * Exit code 0 = all checks pass (warnings allowed), 1 = one or more errors.
+ */
+
+$root = dirname(__DIR__);
+
+$errors = [];
+$warnings = [];
+$checks = 0;
+
+function rel(string $root, string $path): string
+{
+    return ltrim(str_replace($root, '', $path), '/\\');
+}
+
+/**
+ * Minimal front-matter reader: returns [frontmatterAssoc, body] or [null, body].
+ * Supports `key: value` and simple `key:` + `- item` YAML lists. No YAML dep.
+ *
+ * @return array{0: array<string, mixed>|null, 1: string}
+ */
+function read_front_matter(string $contents): array
+{
+    if (! preg_match('/^---\R(.*?)\R---\R?(.*)$/s', $contents, $m)) {
+        return [null, $contents];
+    }
+
+    $data = [];
+    $currentListKey = null;
+    foreach (preg_split('/\R/', $m[1]) as $line) {
+        if (trim($line) === '') {
+            continue;
+        }
+        if (preg_match('/^\s*-\s+(.*)$/', $line, $lm) && $currentListKey !== null) {
+            $data[$currentListKey][] = trim($lm[1], " \"'");
+
+            continue;
+        }
+        if (preg_match('/^([A-Za-z0-9_-]+):\s*(.*)$/', $line, $km)) {
+            $key = $km[1];
+            $value = trim($km[2]);
+            if ($value === '') {
+                $currentListKey = $key;
+                $data[$key] = [];
+            } else {
+                $currentListKey = null;
+                $data[$key] = trim($value, " \"'");
+            }
+        }
+    }
+
+    return [$data, $m[2]];
+}
+
+// ---------------------------------------------------------------------------
+// 1. Required files exist
+// ---------------------------------------------------------------------------
+$required = [
+    'AGENTS.md',
+    'CLAUDE.md',
+    'CODE_MAP.md',
+    'README.md',
+    '.claude/settings.json',
+    '.claude/hooks/guard-destructive.sh',
+    'docs/ai/README.md',
+    'docs/ai/SOURCES.md',
+    'tools/validate-ai-config.php',
+];
+foreach ($required as $file) {
+    $checks++;
+    if (! is_file("$root/$file")) {
+        $errors[] = "Missing required file: $file";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. CLAUDE.md imports the canonical AGENTS.md
+// ---------------------------------------------------------------------------
+$checks++;
+$claude = @file_get_contents("$root/CLAUDE.md") ?: '';
+if (! preg_match('/(^|\s)@(\.\/)?AGENTS\.md(\s|$)/m', $claude)) {
+    $errors[] = 'CLAUDE.md must import the canonical instructions with `@AGENTS.md`.';
+}
+
+$agents = @file_get_contents("$root/AGENTS.md") ?: '';
+
+// ---------------------------------------------------------------------------
+// 3. Skills: SKILL.md present, valid + unique names, name matches directory,
+//    and every skill is referenced in AGENTS.md (Claude <-> Codex sync).
+// ---------------------------------------------------------------------------
+$skillsDir = "$root/.claude/skills";
+$skillNames = [];
+$skillBodies = [];
+if (is_dir($skillsDir)) {
+    foreach (glob("$skillsDir/*", GLOB_ONLYDIR) as $dir) {
+        $dirName = basename($dir);
+        $skillFile = "$dir/SKILL.md";
+        $checks++;
+        if (! is_file($skillFile)) {
+            $errors[] = "Skill '$dirName' is missing SKILL.md";
+
+            continue;
+        }
+        [$fm, $body] = read_front_matter((string) file_get_contents($skillFile));
+        if ($fm === null) {
+            $errors[] = "Skill '$dirName' SKILL.md has no YAML front matter";
+
+            continue;
+        }
+        $name = $fm['name'] ?? null;
+        if (! is_string($name) || $name === '') {
+            $errors[] = "Skill '$dirName' is missing a 'name' field";
+            $name = $dirName;
+        }
+        if (empty($fm['description']) || ! is_string($fm['description'])) {
+            $errors[] = "Skill '$dirName' is missing a 'description' field";
+        } elseif (strlen($fm['description']) > 1024) {
+            $errors[] = "Skill '$dirName' description exceeds 1024 characters";
+        }
+        if (is_string($name) && ! preg_match('/^[a-z0-9]+(-[a-z0-9]+)*$/', $name)) {
+            $errors[] = "Skill '$dirName' name '$name' must be lowercase alphanumeric with single hyphens";
+        }
+        if (is_string($name) && strlen($name) > 64) {
+            $errors[] = "Skill '$dirName' name exceeds 64 characters";
+        }
+        if ($name !== $dirName) {
+            $errors[] = "Skill '$dirName' name '$name' must match its directory name";
+        }
+        if (isset($skillNames[$name])) {
+            $errors[] = "Duplicate skill name '$name'";
+        }
+        $skillNames[$name] = true;
+        $bodyHash = md5(preg_replace('/\s+/', ' ', trim($body)) ?? '');
+        if (isset($skillBodies[$bodyHash])) {
+            $warnings[] = "Skill '$dirName' body is identical to '{$skillBodies[$bodyHash]}' (possible drift/copy)";
+        }
+        $skillBodies[$bodyHash] = $dirName;
+
+        // Sync check: referenced in AGENTS.md so Codex/AGENTS.md-aware tools find it.
+        $checks++;
+        if (strpos($agents, (string) $dirName) === false) {
+            $errors[] = "Skill '$dirName' is not referenced in AGENTS.md (Claude/Codex skill discovery would drift)";
+        }
+    }
+}
+if ($skillNames === []) {
+    $warnings[] = 'No skills found under .claude/skills/';
+}
+
+// Reverse sync: skill-shaped names mentioned in AGENTS.md must exist on disk.
+if (preg_match_all('/`(fetch-php-[a-z0-9-]+)`/', $agents, $mm)) {
+    foreach (array_unique($mm[1]) as $mentioned) {
+        $checks++;
+        if (! isset($skillNames[$mentioned])) {
+            $errors[] = "AGENTS.md references skill '$mentioned' which has no .claude/skills/$mentioned/SKILL.md";
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Subagents: name + description present and unique.
+// ---------------------------------------------------------------------------
+$agentNames = [];
+foreach (glob("$root/.claude/agents/*.md") ?: [] as $file) {
+    $checks++;
+    [$fm] = read_front_matter((string) file_get_contents($file));
+    $base = rel($root, $file);
+    if ($fm === null) {
+        $errors[] = "Subagent $base has no YAML front matter";
+
+        continue;
+    }
+    if (empty($fm['name']) || ! is_string($fm['name'])) {
+        $errors[] = "Subagent $base is missing a 'name' field";
+    } else {
+        if (isset($agentNames[$fm['name']])) {
+            $errors[] = "Duplicate subagent name '{$fm['name']}'";
+        }
+        $agentNames[$fm['name']] = true;
+    }
+    if (empty($fm['description']) || ! is_string($fm['description'])) {
+        $errors[] = "Subagent $base is missing a 'description' field";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Rules: front matter (when present) must expose `paths` as a list.
+// ---------------------------------------------------------------------------
+foreach (glob("$root/.claude/rules/*.md") ?: [] as $file) {
+    $checks++;
+    [$fm] = read_front_matter((string) file_get_contents($file));
+    $base = rel($root, $file);
+    if ($fm !== null && array_key_exists('paths', $fm) && ! is_array($fm['paths'])) {
+        $errors[] = "Rule $base has a 'paths' field that is not a YAML list";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. JSON config files parse.
+// ---------------------------------------------------------------------------
+foreach (['.claude/settings.json', '.claude/settings.local.json', 'composer.json', 'package.json', 'context7.json'] as $json) {
+    $path = "$root/$json";
+    if (! is_file($path)) {
+        continue;
+    }
+    $checks++;
+    json_decode((string) file_get_contents($path));
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        $errors[] = "$json is not valid JSON: ".json_last_error_msg();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. No personal absolute paths or secret-looking material in the AI surface.
+// ---------------------------------------------------------------------------
+$surface = array_merge(
+    ['AGENTS.md', 'CLAUDE.md', '.claude/settings.json'],
+    array_map(fn ($f) => rel($root, $f), glob("$root/.claude/skills/*/SKILL.md") ?: []),
+    array_map(fn ($f) => rel($root, $f), glob("$root/.claude/rules/*.md") ?: []),
+    array_map(fn ($f) => rel($root, $f), glob("$root/.claude/agents/*.md") ?: []),
+);
+$pathPatterns = ['#/home/[a-z0-9._-]+/#i', '#/Users/[a-z0-9._-]+/#i', '#[A-Z]:\\\\Users\\\\#i', '#/root/#'];
+$secretPatterns = [
+    '/AKIA[0-9A-Z]{16}/',
+    '/ghp_[A-Za-z0-9]{36}/',
+    '/xox[baprs]-[A-Za-z0-9-]{10,}/',
+    '/-----BEGIN [A-Z ]*PRIVATE KEY-----/',
+    '/(api[_-]?token|secret|password)\s*[=:]\s*["\']?[A-Za-z0-9]{16,}/i',
+];
+foreach ($surface as $file) {
+    $path = "$root/$file";
+    if (! is_file($path)) {
+        continue;
+    }
+    $checks++;
+    $contents = (string) file_get_contents($path);
+    foreach ($pathPatterns as $p) {
+        if (preg_match($p, $contents)) {
+            $errors[] = "$file contains a personal absolute path (matched $p)";
+        }
+    }
+    foreach ($secretPatterns as $p) {
+        if (preg_match($p, $contents)) {
+            $errors[] = "$file contains a possible secret (matched $p)";
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 8. External sources are documented.
+// ---------------------------------------------------------------------------
+$checks++;
+$sources = @file_get_contents("$root/docs/ai/SOURCES.md") ?: '';
+if (strlen(trim($sources)) < 200) {
+    $warnings[] = 'docs/ai/SOURCES.md looks empty — external sources should be attributed there.';
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+echo "Fetch PHP AI-config validation\n";
+echo str_repeat('-', 34)."\n";
+echo "Checks run: $checks\n";
+foreach ($warnings as $w) {
+    echo "  [warn]  $w\n";
+}
+foreach ($errors as $e) {
+    echo "  [FAIL]  $e\n";
+}
+
+if ($errors === []) {
+    echo count($warnings) > 0
+        ? "\nOK with ".count($warnings)." warning(s).\n"
+        : "\nAll checks passed.\n";
+    exit(0);
+}
+
+echo "\n".count($errors)." error(s), ".count($warnings)." warning(s).\n";
+exit(1);


### PR DESCRIPTION
## Purpose

Add a tailored, cross-agent AI development configuration for Fetch PHP, targeting
**Claude Code** and **OpenAI Codex** first while staying compatible with the
`AGENTS.md` / Agent Skills standard. **No library runtime code changes** — this is
docs, agent config, and a standalone validator only.

## Approach

- **`AGENTS.md`** rewritten as the canonical, vendor-neutral source of truth.
- **`CLAUDE.md`** now imports `@AGENTS.md` and keeps only Claude-specific,
  additive guidance (plan-mode, skill routing, subagents, verification).
- **10 skills** (`.claude/skills/`): implement-change, test-development,
  debug-failure, code-review, http-security-review, performance-review,
  public-api-review, ci-triage, documentation-sync, plus the audited release skill.
- **6 subagents** (`.claude/agents/`): maintainer + test engineer, and read-only
  reviewers (http-security, public-api, documentation, ci).
- **7 path-scoped rules** (`.claude/rules/`) using `paths:` frontmatter.
- **`.claude/settings.json`** — conservative allow/ask/deny permissions — plus a
  POSIX `PreToolUse` hook blocking destructive Git / catastrophic `rm`.
- **`docs/ai/`** guide + license-verified `SOURCES.md`, a CONTRIBUTING AI section,
  and a dependency-free validator: `composer ai:validate`.

## Instruction drift corrected against the repo

- Removed references to a nonexistent `bin/` script dir; documented the real
  Composer/npm commands.
- `composer lint` scope (Duster only, not PHPStan); coverage command.
- CI matrix now PHP **8.3/8.4/8.5** + prefer-lowest (was "8.3/8.4").
- `jerome/matrix` `^3.4` (was "3.3+").
- Clarified `NO_NETWORK=1` semantics (CI guard; no test branches on it).

## Validation run

- `composer ai:validate` — **85 checks pass** (via `php:8.4-cli`).
- `composer validate --strict` — `composer.json` valid.
- `npm run build` — docs build succeeds (AI docs excluded via `srcExclude`).
- Guard hook — 12/12 behavior cases pass.

> Note: `composer check` (PHPStan/Duster/PHPUnit) was **not** run in my
> environment (no local PHP/Composer). No `src/` files changed, so the runtime
> gate is unaffected; CI runs it here. `composer ai:validate` is intentionally
> **not** wired into `composer check`/CI, and no runtime dependency was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
